### PR TITLE
Feature/46 リファクタ/スキル名・カテゴリをソース側で保持

### DIFF
--- a/src/app/interfaces/aggregation-result.ts
+++ b/src/app/interfaces/aggregation-result.ts
@@ -6,8 +6,6 @@ import { AngularFirestoreDocument } from '@angular/fire/firestore/public_api';
  */
 export interface AggregationResult {
   skillId: string;
-  skillCaption: string;
-  skillCategories: string[];
   price: number;
   vacancy: number;
 }

--- a/src/app/interfaces/skill.ts
+++ b/src/app/interfaces/skill.ts
@@ -1,0 +1,7 @@
+import { AngularFirestoreDocument } from '@angular/fire/firestore/public_api';
+
+export interface Skill {
+  skillId: string;
+  skillCaption: string;
+  skillCategories: string[];
+}

--- a/src/app/pipes/result-to-skill.pipe.spec.ts
+++ b/src/app/pipes/result-to-skill.pipe.spec.ts
@@ -1,0 +1,9 @@
+import { ResultToSkillPipe } from './result-to-skill.pipe';
+import { SkillService } from '../services/skill.service';
+
+describe('ResultToSkillPipe', () => {
+  it('create an instance', () => {
+    const pipe = new ResultToSkillPipe(new SkillService());
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/result-to-skill.pipe.ts
+++ b/src/app/pipes/result-to-skill.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { AggregationResult } from '../interfaces/aggregation-result';
+import { Skill } from '../interfaces/skill';
+import { SkillService } from '../services/skill.service';
+
+@Pipe({
+  name: 'resultToSkill',
+})
+export class ResultToSkillPipe implements PipeTransform {
+  constructor(private skillService: SkillService) {}
+
+  transform(result: AggregationResult): Skill {
+    return this.skillService.getSkill(result.skillId);
+  }
+}

--- a/src/app/ranking/ranking.module.ts
+++ b/src/app/ranking/ranking.module.ts
@@ -8,9 +8,10 @@ import { SharedModule } from '../shared/shared.module';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { ResultToSkillPipe } from '../pipes/result-to-skill.pipe';
 
 @NgModule({
-  declarations: [RankingComponent, ResultComponent],
+  declarations: [RankingComponent, ResultComponent, ResultToSkillPipe],
   imports: [
     CommonModule,
     RankingRoutingModule,

--- a/src/app/ranking/result/result.component.html
+++ b/src/app/ranking/result/result.component.html
@@ -4,7 +4,7 @@
       class="avatar"
       mat-card-avatar
       style="background-image:
-      url('/assets/images/skill/{{ (result | resultToSkill).skillId }}.svg');"
+      url('/assets/images/skill/{{ result.skillId }}.svg');"
     ></div>
     <mat-card-title
       >{{ rank }}. {{ (result | resultToSkill).skillCaption }}</mat-card-title

--- a/src/app/ranking/result/result.component.html
+++ b/src/app/ranking/result/result.component.html
@@ -4,13 +4,18 @@
       class="avatar"
       mat-card-avatar
       style="background-image:
-      url('/assets/images/skill/{{ result.skillId }}.svg');"
+      url('/assets/images/skill/{{ (result | resultToSkill).skillId }}.svg');"
     ></div>
-    <mat-card-title>{{ rank }}. {{ result.skillCaption }}</mat-card-title>
+    <mat-card-title
+      >{{ rank }}. {{ (result | resultToSkill).skillCaption }}</mat-card-title
+    >
     <mat-card-subtitle>
       <div>
         <ng-container
-          *ngFor="let category of getSkillCategries(); first as isFirst"
+          *ngFor="
+            let category of (result | resultToSkill).skillCategories;
+            first as isFirst
+          "
         >
           <a class="caterogy" href="">
             <span class="category__caption">{{ category }}</span>

--- a/src/app/ranking/result/result.component.ts
+++ b/src/app/ranking/result/result.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { AggregationResult } from 'src/app/interfaces/aggregation-result';
+import { ResultToSkillPipe } from 'src/app/pipes/result-to-skill.pipe';
 
 @Component({
   selector: 'app-result',
@@ -13,8 +14,4 @@ export class ResultComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {}
-
-  getSkillCategries(): string[] {
-    return this.result.skillCategories;
-  }
 }

--- a/src/app/services/skill.service.spec.ts
+++ b/src/app/services/skill.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SkillService } from './skill.service';
+
+describe('SkillService', () => {
+  let service: SkillService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SkillService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/skill.service.ts
+++ b/src/app/services/skill.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { Skill } from '../interfaces/skill';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SkillService {
+  static SKILLS: ReadonlyArray<Skill> = [
+    {
+      skillId: 'angular',
+      skillCaption: 'Angular',
+      skillCategories: [
+        'フレームワーク',
+        'TypeScript',
+        'フロントエンド',
+        'CategoryA',
+      ],
+    },
+    {
+      skillId: 'vue',
+      skillCaption: 'Vue',
+      skillCategories: [
+        'フレームワーク',
+        'TypeScript',
+        'フロントエンド',
+        'CategoryV',
+      ],
+    },
+    {
+      skillId: 'react',
+      skillCaption: 'React',
+      skillCategories: [
+        'フレームワーク',
+        'TypeScript',
+        'フロントエンド',
+        'CategoryR',
+      ],
+    },
+    {
+      skillId: 'java',
+      skillCaption: 'Java',
+      skillCategories: ['言語', 'バックエンド', 'CategoryJ'],
+    },
+  ];
+
+  constructor() {}
+
+  getSkill(skillId: string): Skill {
+    return SkillService.SKILLS.find((skill) => skill.skillId === skillId);
+  }
+}


### PR DESCRIPTION
fix #46.

## やったこと
firestoreのドキュメント側で保持していたスキル名・スキルカテゴリの情報を、ソース側(SkillService&Skillインターフェイス)で管理するように修正しました。

firestoreドキュメント上はSkillIdのみ保持し、ソース側でパイプ経由(resultToSkill)でスキル情報を取得するようにしました。

修正前の状態だと、途中でスキルカテゴリなどに追加・修正があった場合に、firestoreの全データの更新が必要になってしまっていましたが、本修正によってソースの該当箇所のみ修正すれば良くなりました。

※今日のMTGでのpipe解説を参考に、pipeの練習も兼ねて忘れないうちに実装してみました！

## 画面
画面に変更はありません。
![画面](https://user-images.githubusercontent.com/45328438/82147111-81455400-9888-11ea-97e6-25afd12c1ddc.png)

## firestoreデータ構造
aggregation-resultドキュメントから、SkillCaption,SkillCategoriesのフィールドを削除しました。
![firestore](https://user-images.githubusercontent.com/45328438/82147109-7e4a6380-9888-11ea-81ba-477d7be0d59a.png)
