### PR TITLE
fix(navi): subheaderの修正 #56

### DIFF
--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -1,15 +1,15 @@
-<h2 mat-subheader>ランキング</h2>
-<mat-nav-list dense class="item-group">
-  <a mat-list-item class="item" routerLink="/">総合</a>
-  <a mat-list-item class="item" routerLink="/">推移チャート</a>
-  <a mat-list-item class="item" routerLink="/">条件別</a>
+<mat-nav-list dense>
+  <h2 mat-subheader>ランキング</h2>
+  <a mat-list-item routerLink="/">総合</a>
+  <a mat-list-item routerLink="/">推移チャート</a>
+  <a mat-list-item routerLink="/">条件別</a>
 </mat-nav-list>
 
 <mat-divider></mat-divider>
 
-<h2 mat-subheader>参考情報</h2>
 <mat-nav-list dense>
-  <a mat-list-item class="item" routerLink="/">スクール</a>
-  <a mat-list-item class="item" routerLink="/">教材</a>
-  <a mat-list-item class="item" routerLink="/">インフルエンサー</a>
+  <h2 mat-subheader>参考情報</h2>
+  <a mat-list-item routerLink="/">スクール</a>
+  <a mat-list-item routerLink="/">教材</a>
+  <a mat-list-item routerLink="/">インフルエンサー</a>
 </mat-nav-list>

--- a/src/app/navigation/navigation.component.scss
+++ b/src/app/navigation/navigation.component.scss
@@ -1,5 +1,3 @@
-h2 {
-  margin: 8px 16px 0px;
-  padding: 0px;
-  color: rgba(0, 0, 0, 0.54);
+mat-nav-list {
+  margin-top: 8px;
 }


### PR DESCRIPTION
fix #56.

# 概要
本日(5/31)のMTGにてアドバイスいただいた件です。

サイドナビゲーションメニューにて、コンテンツカテゴリ(h2)をsubheaderに対応しました。

mat-subheader自体は使っていたのですが、mat-nav-listの外側に定義してしまっていたので、subheaderの標準的なstyleが適用されていませんでした。

# やったこと
 ヘッダ(mat-subheader)を、mat-nav-list内に移動
 不要なstyle,classの削除

# 画面イメージ
・修正後
![スクリーンショット 2020-05-31 18 35 41](https://user-images.githubusercontent.com/45328438/83349183-cb8d0180-a36d-11ea-988b-dedda46f261c.png)

・修正前
![スクリーンショット 2020-05-31 20 45 28](https://user-images.githubusercontent.com/45328438/83351518-b15c1f00-a37f-11ea-8d73-dc28ee1e985e.png)
