### PR TITLE
スキル一覧/画面実装 #60

### DIFF
--- a/src/app/ranking/result/result.component.html
+++ b/src/app/ranking/result/result.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card routerLink="skill/{{ result.skillId }}">
   <mat-card-header>
     <div
       class="avatar"

--- a/src/app/services/skill.service.ts
+++ b/src/app/services/skill.service.ts
@@ -48,4 +48,8 @@ export class SkillService {
   getSkill(skillId: string): Skill {
     return SkillService.SKILLS.find((skill) => skill.skillId === skillId);
   }
+
+  getSkills(): Skill[] {
+    return SkillService.SKILLS.concat();
+  }
 }

--- a/src/app/skill-list/skill-list-card/skill-list-card.component.html
+++ b/src/app/skill-list/skill-list-card/skill-list-card.component.html
@@ -1,2 +1,17 @@
-<p>skill-list-card works!</p>
-<p>{{ skill.skillCaption }}</p>
+<mat-card routerLink="/skill/{{ skill.skillId }}">
+  <img mat-card-sm-image src="/assets/images/skill/{{ skill.skillId }}.svg" />
+  <mat-card-content>
+    <h3>{{ skill.skillCaption }}</h3>
+
+    <div class="categories">
+      <div
+        class="caterogy-block"
+        *ngFor="let category of skill.skillCategories"
+      >
+        <a class="caterogy" href="">
+          <span class="category__caption">{{ category }}</span>
+        </a>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/skill-list/skill-list-card/skill-list-card.component.html
+++ b/src/app/skill-list/skill-list-card/skill-list-card.component.html
@@ -1,0 +1,2 @@
+<p>skill-list-card works!</p>
+<p>{{ skill.skillCaption }}</p>

--- a/src/app/skill-list/skill-list-card/skill-list-card.component.scss
+++ b/src/app/skill-list/skill-list-card/skill-list-card.component.scss
@@ -1,0 +1,39 @@
+mat-card {
+  width: 160px;
+  height: 160px;
+}
+
+img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 8px;
+}
+
+h3 {
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.categories {
+  text-align: center;
+}
+
+.caterogy-block {
+  display: inline-block;
+}
+
+.caterogy {
+  background-color: #eee;
+  color: #666;
+  padding: 3px 4px;
+  border-radius: 3px;
+  margin-right: 4px;
+  margin-bottom: 3px;
+  font-size: 8px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.caterogy:hover {
+  text-decoration: underline;
+}

--- a/src/app/skill-list/skill-list-card/skill-list-card.component.spec.ts
+++ b/src/app/skill-list/skill-list-card/skill-list-card.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkillListCardComponent } from './skill-list-card.component';
+
+describe('SkillListCardComponent', () => {
+  let component: SkillListCardComponent;
+  let fixture: ComponentFixture<SkillListCardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SkillListCardComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SkillListCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/skill-list/skill-list-card/skill-list-card.component.ts
+++ b/src/app/skill-list/skill-list-card/skill-list-card.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { Skill } from 'src/app/interfaces/skill';
+
+@Component({
+  selector: 'app-skill-list-card',
+  templateUrl: './skill-list-card.component.html',
+  styleUrls: ['./skill-list-card.component.scss'],
+})
+export class SkillListCardComponent implements OnInit {
+  @Input() skill: Skill;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/skill-list/skill-list.module.ts
+++ b/src/app/skill-list/skill-list.module.ts
@@ -2,9 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { SkillListRoutingModule } from './skill-list-routing.module';
+import { SkillListComponent } from './skill-list/skill-list.component';
+import { SkillListCardComponent } from './skill-list-card/skill-list-card.component';
 
 @NgModule({
-  declarations: [],
+  declarations: [SkillListComponent, SkillListCardComponent],
   imports: [CommonModule, SkillListRoutingModule],
 })
 export class SkillListModule {}

--- a/src/app/skill-list/skill-list.module.ts
+++ b/src/app/skill-list/skill-list.module.ts
@@ -4,9 +4,16 @@ import { CommonModule } from '@angular/common';
 import { SkillListRoutingModule } from './skill-list-routing.module';
 import { SkillListComponent } from './skill-list/skill-list.component';
 import { SkillListCardComponent } from './skill-list-card/skill-list-card.component';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { MatCardModule } from '@angular/material/card';
 
 @NgModule({
   declarations: [SkillListComponent, SkillListCardComponent],
-  imports: [CommonModule, SkillListRoutingModule],
+  imports: [
+    CommonModule,
+    SkillListRoutingModule,
+    MatGridListModule,
+    MatCardModule,
+  ],
 })
 export class SkillListModule {}

--- a/src/app/skill-list/skill-list/skill-list.component.html
+++ b/src/app/skill-list/skill-list/skill-list.component.html
@@ -1,4 +1,6 @@
-<p>skill-list works!</p>
-
-<app-skill-list-card *ngFor="let skill of getSkills()" [skill]="skill">
-</app-skill-list-card>
+<div class="container">
+  <div class="grid">
+    <app-skill-list-card *ngFor="let skill of getSkills()" [skill]="skill">
+    </app-skill-list-card>
+  </div>
+</div>

--- a/src/app/skill-list/skill-list/skill-list.component.html
+++ b/src/app/skill-list/skill-list/skill-list.component.html
@@ -1,1 +1,4 @@
 <p>skill-list works!</p>
+
+<app-skill-list-card *ngFor="let skill of getSkills()" [skill]="skill">
+</app-skill-list-card>

--- a/src/app/skill-list/skill-list/skill-list.component.scss
+++ b/src/app/skill-list/skill-list/skill-list.component.scss
@@ -1,0 +1,5 @@
+.grid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fill, 190px);
+}

--- a/src/app/skill-list/skill-list/skill-list.component.ts
+++ b/src/app/skill-list/skill-list/skill-list.component.ts
@@ -1,4 +1,9 @@
 import { Component, OnInit } from '@angular/core';
+import { AggregationResult } from 'src/app/interfaces/aggregation-result';
+import { AggregationResultService } from 'src/app/services/aggregation-result.service';
+import { Observable } from 'rxjs';
+import { Skill } from 'src/app/interfaces/skill';
+import { SkillService } from 'src/app/services/skill.service';
 
 @Component({
   selector: 'app-skill-list',
@@ -6,7 +11,12 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./skill-list.component.scss'],
 })
 export class SkillListComponent implements OnInit {
-  constructor() {}
+  constructor(private skillService: SkillService) {}
 
   ngOnInit(): void {}
+
+  // 暫定メソッド(ゆくゆくはAlgoliaにてデータ取得)
+  getSkills(): Skill[] {
+    return this.skillService.getSkills();
+  }
 }


### PR DESCRIPTION
fix #60 

以下、レビューをお願いできますでしょうか？

## 概要
スキル一覧の画面実装

## やったこと
- [x] gridの実装
- [x] カード用のcomponent追加・実装
- [x] ランキング&スキル一覧から、スキル詳細へのリンク追加

## 今後のタスクなど
カテゴリ(tag)によるフィルタの実装(Algolia導入)
ヘッダーの検索欄からの検索結果一覧表示・オートコンプリート等

※補足
前回、やっていたスキル詳細画面がまだ途中ですが、とりあえずngx chartsの実装が完了したので、一旦中断しています。

まずは、メインコンテンツの作成に必要な技術・ライブラリを一通りキャッチアップしてから、細かいところを作り込もうと思っています。
(ある程度進んだあとで、データ構造やロジックの大幅な見直しが入るとロスなので、まずは浅くても一通りやっていこうと思っています)

- [x] firebase/firestore
- [x] ngx charts
- [ ] algolia
- [ ] スクレイピング(Puppeteer)
- [ ] firebase/function
- [ ] firebase/auth
- [ ] stripe

## 画面イメージ
repeat(auto-fill)にて、ウィンドウサイズに応じたカラム数になるように対応。

![grid1](https://user-images.githubusercontent.com/45328438/83935395-3918b200-a7f4-11ea-816d-0f26f39bb2ea.png)
![grid2](https://user-images.githubusercontent.com/45328438/83935399-3b7b0c00-a7f4-11ea-8267-428753ac4bff.png)
![grid3](https://user-images.githubusercontent.com/45328438/83935400-3d44cf80-a7f4-11ea-87c6-8cbad573d38d.png)

