### PR TITLE
スキル一覧/Algolia対応 & 検索ボタンの実装 #62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,121 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.3.0.tgz",
+      "integrity": "sha512-91Cf3IPUk84PF2wvR8ys8XO42FqaJEtIh/dyR0WvwMdv0x13GORkAvoBJgkFI2wofZqUY86jNimvHWfsWzPQ+g==",
+      "requires": {
+        "@algolia/cache-common": "4.3.0"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.3.0.tgz",
+      "integrity": "sha512-AHTbOn9lk0f5IkjssXXmDgnaZfsUJVZ61sqOH1W3LyJdAscDzCj0KtwijELn8FHlLXQak7+K93/O3Oct0uHncQ=="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.3.0.tgz",
+      "integrity": "sha512-8BZS5IFEtiSFkA6vNQUXJXIWABDbSanQdkGX5LArlhbCjuykZqF68yaCjXWG10EZTySnkZLmKc+5ozYVOktJaQ==",
+      "requires": {
+        "@algolia/cache-common": "4.3.0"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.3.0.tgz",
+      "integrity": "sha512-8LJSvWooc+fe+XZXeu+h4dhpo9lsu3sb7rV9cpPhymYSHgEJAHaDkZEcPM1u/PBMvFe0mZXaW6nabeb3jeIRcw==",
+      "requires": {
+        "@algolia/client-common": "4.3.0",
+        "@algolia/client-search": "4.3.0",
+        "@algolia/transporter": "4.3.0"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.3.0.tgz",
+      "integrity": "sha512-BFH4ddyrqI2pE3bUctn5KtJgYqgvO0Ap9vJEHBNj6mjSKqFbTnZeVEPG3yWrOuWRCqPHR3ewcWRisNwJHG3+Mw==",
+      "requires": {
+        "@algolia/client-common": "4.3.0",
+        "@algolia/client-search": "4.3.0",
+        "@algolia/requester-common": "4.3.0",
+        "@algolia/transporter": "4.3.0"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.3.0.tgz",
+      "integrity": "sha512-8Ohj6zXZkpwDKc8ZWVTZo2wPO4+LT5D258suGg/C6nh4UxOrFOp6QaqeQo8JZ1eqMqtfb3zv5SHgW4fZ00NCLQ==",
+      "requires": {
+        "@algolia/requester-common": "4.3.0",
+        "@algolia/transporter": "4.3.0"
+      }
+    },
+    "@algolia/client-recommendation": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-recommendation/-/client-recommendation-4.3.0.tgz",
+      "integrity": "sha512-jCMIAWPA2hsxc5CCtoTtQAcohaG+10CxXK122Tc47t4w1K8qzSJnCjC2cHvM4UNJO+k7NrmjOYW0EXp9RKc7SQ==",
+      "requires": {
+        "@algolia/client-common": "4.3.0",
+        "@algolia/requester-common": "4.3.0",
+        "@algolia/transporter": "4.3.0"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.3.0.tgz",
+      "integrity": "sha512-KCgcIsNMW1/0F5OILiFTddbTAKduJHRvXQS4NxY1H9gQWMTVeWJS7VZQ/ukKBiUMLatwUQHJz2qpYm9fmqOjkQ==",
+      "requires": {
+        "@algolia/client-common": "4.3.0",
+        "@algolia/requester-common": "4.3.0",
+        "@algolia/transporter": "4.3.0"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.3.0.tgz",
+      "integrity": "sha512-vQ+aukjZkRAyO9iyINBefT366UtF/B9QoA1Kw8PlY67T6fYmklFgYp3LNH/e7h/gz0py5LYY/HIwSsaTKk8/VQ=="
+    },
+    "@algolia/logger-console": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.3.0.tgz",
+      "integrity": "sha512-7pWtcv1cSSa7F48gRBOZLcEWN073+WbnKjbpRrIGej+abZppw/h+22jtVZZORC8EIjFffGqz2/2e6bZiX+Jg7A==",
+      "requires": {
+        "@algolia/logger-common": "4.3.0"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.3.0.tgz",
+      "integrity": "sha512-CpUwgQhXZsnZmjEd5DTwQv1BKQNCt83bzyVdUqvljsFxZOsNQacS6lOYs0B1eD18tKHCwVMuwbYqTaLPGBXTKQ==",
+      "requires": {
+        "@algolia/requester-common": "4.3.0"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.3.0.tgz",
+      "integrity": "sha512-1v73KyspJBiTzfyXupjHxikxTYjh5MoxI6mOIvAtQxRqc4ehUPAEdPCNHEvvLiCK96iKWzZaULmV0U7pj3yvTw=="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.3.0.tgz",
+      "integrity": "sha512-Hg9Y8sUeSGQgoO1FpoL5jbkDzCtXI/8HXHybU6bimsX93DAz3HZWaoQFKmIpQDNhQ8G9FLgAtzDAxS6eckDxzg==",
+      "requires": {
+        "@algolia/requester-common": "4.3.0"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.3.0.tgz",
+      "integrity": "sha512-BTKHAtdQdfOJ0xzZkiyEK/2QVQJTiVgBZlOBfXp2gBtztjV26OqfW4n6Xz0o7eBRzLEwY1ot3mHF5QIVUjAsMg==",
+      "requires": {
+        "@algolia/cache-common": "4.3.0",
+        "@algolia/logger-common": "4.3.0",
+        "@algolia/requester-common": "4.3.0"
+      }
+    },
     "@angular-devkit/architect": {
       "version": "0.900.7",
       "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.900.7.tgz",
@@ -2662,60 +2777,24 @@
       "dev": true
     },
     "algoliasearch": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-3.35.1.tgz",
-      "integrity": "sha512-K4yKVhaHkXfJ/xcUnil04xiSrB8B8yHZoFEhWNpXg23eiCnqvTZw1tn/SqvdsANlYHLJlKl0qi3I/Q2Sqo7LwQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.3.0.tgz",
+      "integrity": "sha512-H2woXyqmd1nFYDrQKLZXgghNkLBTcBXJ7Q/bxQ+F9WWS4H0Kb7IlQvNi7bDzHyldhDhIthImaUwcKqr5iiyMFQ==",
       "requires": {
-        "agentkeepalive": "^2.2.0",
-        "debug": "^2.6.9",
-        "envify": "^4.0.0",
-        "es6-promise": "^4.1.0",
-        "events": "^1.1.0",
-        "foreach": "^2.0.5",
-        "global": "^4.3.2",
-        "inherits": "^2.0.1",
-        "isarray": "^2.0.1",
-        "load-script": "^1.0.0",
-        "object-keys": "^1.0.11",
-        "querystring-es3": "^0.2.1",
-        "reduce": "^1.0.1",
-        "semver": "^5.1.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "agentkeepalive": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-2.2.0.tgz",
-          "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "events": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-        },
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "@algolia/cache-browser-local-storage": "4.3.0",
+        "@algolia/cache-common": "4.3.0",
+        "@algolia/cache-in-memory": "4.3.0",
+        "@algolia/client-account": "4.3.0",
+        "@algolia/client-analytics": "4.3.0",
+        "@algolia/client-common": "4.3.0",
+        "@algolia/client-recommendation": "4.3.0",
+        "@algolia/client-search": "4.3.0",
+        "@algolia/logger-common": "4.3.0",
+        "@algolia/logger-console": "4.3.0",
+        "@algolia/requester-browser-xhr": "4.3.0",
+        "@algolia/requester-common": "4.3.0",
+        "@algolia/requester-node-http": "4.3.0",
+        "@algolia/transporter": "4.3.0"
       }
     },
     "alphanum-sort": {
@@ -5602,11 +5681,6 @@
       "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
       "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q=="
     },
-    "dom-walk": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -5889,15 +5963,6 @@
       "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
       "dev": true
     },
-    "envify": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
-      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
-      "requires": {
-        "esprima": "^4.0.0",
-        "through": "~2.3.4"
-      }
-    },
     "err-code": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
@@ -5977,7 +6042,8 @@
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -6035,7 +6101,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
@@ -7062,11 +7129,6 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7343,15 +7405,6 @@
         "glob-slash": "^1.0.0",
         "lodash.isobject": "^2.4.1",
         "toxic": "^1.0.0"
-      }
-    },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
       }
     },
     "global-dirs": {
@@ -8333,7 +8386,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -9767,11 +9821,6 @@
       "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
       "dev": true
     },
-    "load-script": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
-      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
-    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
@@ -10437,14 +10486,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
     },
     "mini-css-extract-plugin": {
       "version": "0.9.0",
@@ -11139,7 +11180,8 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -12775,7 +12817,8 @@
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -13152,7 +13195,8 @@
     "querystring-es3": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
     },
     "querystringify": {
       "version": "2.1.1",
@@ -13333,14 +13377,6 @@
       "dev": true,
       "requires": {
         "esprima": "~4.0.0"
-      }
-    },
-    "reduce": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/reduce/-/reduce-1.0.2.tgz",
-      "integrity": "sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==",
-      "requires": {
-        "object-keys": "^1.1.0"
       }
     },
     "reflect-metadata": {
@@ -15486,7 +15522,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.5",
@@ -15712,6 +15749,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@angular/platform-browser-dynamic": "~9.1.3",
     "@angular/router": "~9.1.3",
     "@swimlane/ngx-charts": "^14.0.0",
-    "algoliasearch": "^3.35.1",
+    "algoliasearch": "^4.3.0",
     "firebase": "^7.14.2",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { NavigationComponent } from './navigation/navigation.component';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatListModule } from '@angular/material/list';
 import { FooterComponent } from './footer/footer.component';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 @NgModule({
   declarations: [
@@ -50,6 +51,7 @@ import { FooterComponent } from './footer/footer.component';
     MatIconModule,
     MatSidenavModule,
     MatListModule,
+    MatAutocompleteModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -9,19 +9,35 @@
     </a>
   </div>
 
-  <form [formGroup]="form" (ngSubmit)="submit()" class="search">
+  <form class="search" (ngSubmit)="routeSearch(searchControl.value)">
     <input
       class="search__input"
-      formControlName="searchInput"
+      [formControl]="searchControl"
       matInput
-      placeholder="検索したいスキル名"
-      autocomplate="off"
+      placeholder="検索したいスキル名・カテゴリ"
+      [matAutocomplete]="auto"
     />
 
-    <button class="search__button" mat-icon-button>
+    <button
+      (click)="routeSearch(searchControl.value)"
+      class="search__button"
+      mat-icon-button
+    >
       <mat-icon>search</mat-icon>
     </button>
   </form>
+
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    (optionActivated)="setSearchQuery($event.option?.value)"
+    (optionSelected)="routeSearch($event.option?.value)"
+  >
+    <mat-option
+      *ngFor="let option of autoComplateOptions"
+      [value]="option.skillCaption"
+      >{{ option.skillCaption }}</mat-option
+    >
+  </mat-autocomplete>
 
   <div class="login">
     <button mat-button (click)="uploadSampleData()">サンプルデータ更新</button>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormControl } from '@angular/forms';
 import { NavigationService } from '../services/navigation.service';
 import { SkillService } from '../services/skill.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { debounceTime, startWith } from 'rxjs/operators';
+import { Skill } from '../interfaces/skill';
 
 @Component({
   selector: 'app-header',
@@ -9,20 +12,40 @@ import { SkillService } from '../services/skill.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent implements OnInit {
-  form = this.fb.group({
-    searchInput: ['', [Validators.required]],
-  });
+  searchControl = new FormControl('');
+  autoComplateOptions = [];
+  index = this.skillService.index.skills;
 
   constructor(
-    private fb: FormBuilder,
+    private activatedRoute: ActivatedRoute,
+    private router: Router,
     private navService: NavigationService,
     private skillService: SkillService
   ) {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.searchControl.valueChanges
+      .pipe(startWith(''), debounceTime(500))
+      .subscribe((key) => {
+        this.index.search<Skill[]>(key).then((result) => {
+          this.autoComplateOptions = result.hits;
+        });
+      });
+  }
 
-  submit() {
-    console.log(this.form.value);
+  setSearchQuery(value: string) {
+    this.searchControl.setValue(value, {
+      emitEvent: false,
+    });
+  }
+
+  routeSearch(searchQuery: string) {
+    this.router.navigate(['/skill'], {
+      queryParams: {
+        searchQuery: searchQuery || null,
+      },
+      queryParamsHandling: 'merge',
+    });
   }
 
   login() {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, Validators, FormControl } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { NavigationService } from '../services/navigation.service';
 import { SkillService } from '../services/skill.service';
 

--- a/src/app/services/skill.service.ts
+++ b/src/app/services/skill.service.ts
@@ -3,6 +3,13 @@ import { Skill } from '../interfaces/skill';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { firestore } from 'firebase';
+import { environment } from 'src/environments/environment';
+import algoliasearch from 'algoliasearch/lite';
+
+const searchClient = algoliasearch(
+  environment.algolia.appId,
+  environment.algolia.searchKey
+);
 
 @Injectable({
   providedIn: 'root',
@@ -127,6 +134,11 @@ export class SkillService {
       updatedAt: firestore.Timestamp.now(),
     },
   ];
+
+  index = {
+    skills: searchClient.initIndex('skills'),
+    // ゆくゆくはsort順ごとのindex追加
+  };
 
   constructor(private afs: AngularFirestore) {}
 

--- a/src/app/skill-list/skill-list/skill-list.component.html
+++ b/src/app/skill-list/skill-list/skill-list.component.html
@@ -2,10 +2,7 @@
   <div class="content">
     <h1>スキル一覧</h1>
     <div class="grid">
-      <app-skill-list-card
-        *ngFor="let skill of skills$ | async"
-        [skill]="skill"
-      >
+      <app-skill-list-card *ngFor="let skill of skills" [skill]="skill">
       </app-skill-list-card>
     </div>
   </div>

--- a/src/app/skill-list/skill-list/skill-list.component.ts
+++ b/src/app/skill-list/skill-list/skill-list.component.ts
@@ -40,7 +40,7 @@ export class SkillListComponent implements OnInit {
       this.resultList = [];
       // TODO:要実装
       // this.index = this.searchService.index[map.get('sort') || 'popular'];
-      // this.query = map.get('searchQuery') || '';
+      this.query = map.get('searchQuery') || '';
       // this.requestOptions = {
       //   page: +map.get('page') > 0 ? +map.get('page') - 1 : 0,
       //   hitsPerPage: map.get('perPage') ? +map.get('perPage') : 20,

--- a/src/app/skill-list/skill-list/skill-list.component.ts
+++ b/src/app/skill-list/skill-list/skill-list.component.ts
@@ -1,5 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { SkillService } from 'src/app/services/skill.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Skill } from 'src/app/interfaces/skill';
+import { SearchIndex } from 'algoliasearch/lite';
 
 @Component({
   selector: 'app-skill-list',
@@ -7,9 +10,70 @@ import { SkillService } from 'src/app/services/skill.service';
   styleUrls: ['./skill-list.component.scss'],
 })
 export class SkillListComponent implements OnInit {
-  skills$ = this.skillService.getSkills();
+  skills: Skill[] = [];
 
-  constructor(private skillService: SkillService) {}
+  private index: SearchIndex = this.skillService.index.skills;
 
-  ngOnInit(): void {}
+  // TODO:要実装
+  loading: boolean;
+  scrollMode = false;
+  result: {
+    nbHits: number;
+    hits: any[];
+  }; // TODO: 型対応後調整(https://github.com/algolia/algoliasearch-client-javascript/pull/1086)
+  resultList: Skill[] = [];
+  query: string;
+  requestOptions: any = {}; // TODO: 型対応後調整(https://github.com/algolia/algoliasearch-client-javascript/pull/1086)
+  private tagFilter: {
+    rule: string;
+    tags: string[];
+  };
+
+  constructor(
+    private skillService: SkillService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.route.queryParamMap.subscribe((map) => {
+      this.resultList = [];
+      // TODO:要実装
+      // this.index = this.searchService.index[map.get('sort') || 'popular'];
+      // this.query = map.get('searchQuery') || '';
+      // this.requestOptions = {
+      //   page: +map.get('page') > 0 ? +map.get('page') - 1 : 0,
+      //   hitsPerPage: map.get('perPage') ? +map.get('perPage') : 20,
+      // };
+      // this.tagFilter = {
+      //   rule: map.get('rule')?.match(/and|or/) ? map.get('rule') : 'and',
+      //   tags: map.get('tags') ? map.get('tags').split(',') : [],
+      // };
+      this.algoliaSearch();
+    });
+  }
+
+  algoliaSearch() {
+    // TODO:要実装
+    // const rule = this.tagFilter.tags.map((tag) => 'categories:' + tag);
+
+    console.log('algoliaSearch');
+
+    this.loading = true;
+    this.index
+      .search<Skill>(this.query, {
+        // TODO:要実装
+        //        facetFilters: this.tagFilter.rule === 'and' ? rule : [rule],
+        //        ...this.requestOptions,
+      })
+      .then((result) => {
+        console.log(result);
+        this.result = result;
+        const items = result.hits as any[]; // TODO: 型対応後調整(https://github.com/algolia/algoliasearch-client-javascript/pull/1086)
+        this.resultList.push(...items);
+        this.loading = false;
+
+        this.skills = result.hits as any[];
+      });
+  }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -14,6 +14,10 @@ export const environment = {
     appId: '1:323121777520:web:4fa8afb8c60d9badef9db5',
     measurementId: 'G-10ZZH9657X',
   },
+  algolia: {
+    appId: 'PU529L6FSF',
+    searchKey: '371420ca707829c272e2a7eccd88a85b',
+  },
 };
 
 /*


### PR DESCRIPTION
fix #62 

以下レビューをお願いできますでしょうか。

## 概要
スキル一覧をAlgolia経由でデータ取得するように修正。
また、ヘッダーの検索 及び QueryParamによる絞り込みに対応。

## タスク
- [x] Algoliaバージョンアップ
- [x] environmentに、id/searchkey追加
- [x] ServiceにAlgoliaのsearchclient追加
- [x] componentでAlgolia経由でデータ取得するように修正
- [x] QueryParamを元にAlgoliaのqueryを実行
- [x] headerの検索ボタン実装(上記のQueryParam渡す)
- [x] headerの検索欄にオートコンプリートを追加

## 次回課題
スキル一覧/スキルカテゴリによるフィルタリング(Algoliaのfacet利用) #22

## 画面イメージ
### Algolia設定
スキル名称とカテゴリを検索対象項目に。
![スクリーンショット 2020-06-14 17 43 05](https://user-images.githubusercontent.com/45328438/84589061-1e36e500-ae67-11ea-9dfd-d0c4368e2fd5.png)

![スクリーンショット 2020-06-14 17 42 41](https://user-images.githubusercontent.com/45328438/84589071-2727b680-ae67-11ea-92b0-2ae96225bb24.png)

### Web画面
オートコンプリート
![スクリーンショット 2020-06-14 17 50 20](https://user-images.githubusercontent.com/45328438/84589118-8f769800-ae67-11ea-92d5-722fa8a33f6b.png)

検索値は、queryParamにセット
(URL直接指定でも、検索可能)
![スクリーンショット 2020-06-14 17 44 23](https://user-images.githubusercontent.com/45328438/84589077-3a3a8680-ae67-11ea-8e9d-3ce74407242c.png)
