### PR TITLE
スキル一覧/スキルカテゴリによるフィルタリング(Algoliaのfacet利用) #22

### DIFF
--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.html
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.html
@@ -1,22 +1,25 @@
-<mat-card>
-  <mat-card-content>
-    <h2>カテゴリ絞り込み</h2>
+<h2>タグ一覧</h2>
 
-    <mat-selection-list dense (selectionChange)="updateTags($event)">
-      <mat-list-option
-        *ngFor="let tag of tags"
-        [selected]="tag.selected"
-        [value]="tag.value"
-      >
-        {{ tag.value }}({{ tag.count }})
-      </mat-list-option>
-    </mat-selection-list>
+<div>
+  <label
+    ><input type="radio" value="and" [formControl]="tagRule" checked />
+    AND</label
+  >
+  <label><input type="radio" value="or" [formControl]="tagRule" /> OR</label>
+</div>
 
-    <!-- <button (click)="" mat-icon-button> -->
-    <!-- <button mat-raised-button (click)="clearFilter()">
-      絞り込み解除
-    </button> -->
+<mat-form-field>
+  <mat-label>タグ絞り込み</mat-label>
+  <input type="text" matInput [formControl]="tagFilter" autocomplete="off" />
+</mat-form-field>
 
-    <button mat-button routerLink="./">条件をクリア</button>
-  </mat-card-content>
-</mat-card>
+<mat-selection-list dense (selectionChange)="updateTags($event)">
+  <mat-list-option
+    *ngFor="let tag of tags"
+    [selected]="tag.selected"
+    [value]="tag.value"
+  >
+    {{ tag.value }}({{ tag.count }})
+  </mat-list-option>
+</mat-selection-list>
+<button mat-button routerLink="./">条件をクリア</button>

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.html
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.html
@@ -1,25 +1,36 @@
-<h2>タグ一覧</h2>
+<mat-card>
+  <mat-card-content>
+    <h2>カテゴリ一覧</h2>
 
-<div>
-  <label
-    ><input type="radio" value="and" [formControl]="tagRule" checked />
-    AND</label
-  >
-  <label><input type="radio" value="or" [formControl]="tagRule" /> OR</label>
-</div>
+    <div>
+      <label
+        ><input type="radio" value="and" [formControl]="tagRule" checked />
+        AND</label
+      >
+      <label
+        ><input type="radio" value="or" [formControl]="tagRule" /> OR</label
+      >
+    </div>
 
-<mat-form-field>
-  <mat-label>タグ絞り込み</mat-label>
-  <input type="text" matInput [formControl]="tagFilter" autocomplete="off" />
-</mat-form-field>
+    <mat-form-field>
+      <mat-label>カテゴリ絞り込み</mat-label>
+      <input
+        type="text"
+        matInput
+        [formControl]="tagFilter"
+        autocomplete="off"
+      />
+    </mat-form-field>
 
-<mat-selection-list dense (selectionChange)="updateTags($event)">
-  <mat-list-option
-    *ngFor="let tag of tags"
-    [selected]="tag.selected"
-    [value]="tag.value"
-  >
-    {{ tag.value }}({{ tag.count }})
-  </mat-list-option>
-</mat-selection-list>
-<button mat-button routerLink="./">条件をクリア</button>
+    <mat-selection-list
+      [formControl]="tagControl"
+      dense
+      (selectionChange)="updateTags($event)"
+    >
+      <mat-list-option *ngFor="let tag of tags" [value]="tag.value">
+        {{ tag.value }}({{ tag.count }})
+      </mat-list-option>
+    </mat-selection-list>
+    <button mat-button routerLink="./">条件をクリア</button>
+  </mat-card-content>
+</mat-card>

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.html
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.html
@@ -1,0 +1,22 @@
+<mat-card>
+  <mat-card-content>
+    <h2>カテゴリ絞り込み</h2>
+
+    <mat-selection-list dense (selectionChange)="updateTags($event)">
+      <mat-list-option
+        *ngFor="let tag of tags"
+        [selected]="tag.selected"
+        [value]="tag.value"
+      >
+        {{ tag.value }}({{ tag.count }})
+      </mat-list-option>
+    </mat-selection-list>
+
+    <!-- <button (click)="" mat-icon-button> -->
+    <!-- <button mat-raised-button (click)="clearFilter()">
+      絞り込み解除
+    </button> -->
+
+    <button mat-button routerLink="./">条件をクリア</button>
+  </mat-card-content>
+</mat-card>

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.scss
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.scss
@@ -1,0 +1,6 @@
+h2 {
+  font-weight: normal;
+  font-size: 13px;
+  line-height: 1;
+  margin: 16px 0;
+}

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.spec.ts
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkillListFileterComponent } from './skill-list-fileter.component';
+
+describe('SkillListFileterComponent', () => {
+  let component: SkillListFileterComponent;
+  let fixture: ComponentFixture<SkillListFileterComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SkillListFileterComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SkillListFileterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
@@ -78,7 +78,8 @@ export class SkillListFileterComponent implements OnInit {
     );
     this.updateParams({
       tags: values.length ? values.join(',') : null,
-      page: 1,
+      // TODO:必要があればあとで実装
+      // page: 1,
     });
   }
 }

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
@@ -1,0 +1,94 @@
+import { Component, OnInit } from '@angular/core';
+import { SkillService } from 'src/app/services/skill.service';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FormControl } from '@angular/forms';
+import { MatSelectionListChange } from '@angular/material/list';
+
+@Component({
+  selector: 'app-skill-list-fileter',
+  templateUrl: './skill-list-fileter.component.html',
+  styleUrls: ['./skill-list-fileter.component.scss'],
+})
+export class SkillListFileterComponent implements OnInit {
+  private index = this.skillService.index.skills;
+
+  tags: {
+    value: string;
+    highlighted: string;
+    count: number;
+    selected?: boolean;
+  }[];
+  // tagFilter = new FormControl();
+  // tagRule = new FormControl('and');
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private skillService: SkillService
+  ) {}
+
+  ngOnInit(): void {
+    console.log('ngOnInit');
+
+    this.route.queryParamMap.subscribe((map) => {
+      // this.tagRule.patchValue(map.get('rule') || 'and', {
+      //   emitEvent: false,
+      // });
+
+      // const tagFilter = map.get('tagFilter') || '';
+      // this.tagFilter.patchValue(tagFilter, {
+      //   emitEvent: false,
+      // });
+
+      console.log('skill-list-fileter.subscribe');
+
+      const defaultTags = map.get('tags') ? map.get('tags').split(',') : [];
+      this.buildTags('', defaultTags);
+      // console.log('defaultTags:' + defaultTags);
+
+      // this.tags.forEach((tag) => {
+      //   tag.selected = defaultTags.includes(tag.value);
+      // });
+    });
+
+    // this.tagFilter.valueChanges.subscribe((facetQuery) => {
+    //   this.updateParams({
+    //     tagFilter: facetQuery || null,
+    //   });
+    // });
+    // this.tagRule.valueChanges.subscribe((rule) => {
+    //   this.updateParams({
+    //     rule,
+    //   });
+    // });
+  }
+  private updateParams(params: object) {
+    this.router.navigate([], {
+      queryParamsHandling: 'merge',
+      queryParams: params,
+    });
+  }
+
+  private buildTags(facetQuery: string = '', defaultTags?: string[]) {
+    console.log('buildTags' + defaultTags);
+    this.index.searchForFacetValues('skillCategories', '').then((result) => {
+      console.log('before:' + JSON.stringify(this.tags));
+      this.tags = result.facetHits.map((tag) => ({
+        ...tag,
+        selected: defaultTags && defaultTags.includes(tag.value),
+      }));
+      console.log('after:' + JSON.stringify(this.tags));
+    });
+    this.tags[0].value = this.tags[0].value + '_';
+  }
+
+  updateTags(event: MatSelectionListChange) {
+    const values = event.source.selectedOptions.selected.map(
+      (selected) => selected.value
+    );
+    this.updateParams({
+      tags: values.length ? values.join(',') : null,
+      page: 1,
+    });
+  }
+}

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
@@ -3,6 +3,7 @@ import { SkillService } from 'src/app/services/skill.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl } from '@angular/forms';
 import { MatSelectionListChange } from '@angular/material/list';
+import { JsonPipe } from '@angular/common';
 
 @Component({
   selector: 'app-skill-list-fileter',
@@ -17,9 +18,9 @@ export class SkillListFileterComponent implements OnInit {
     highlighted: string;
     count: number;
     selected?: boolean;
-  }[];
-  // tagFilter = new FormControl();
-  // tagRule = new FormControl('and');
+  }[] = [];
+  tagFilter = new FormControl();
+  tagRule = new FormControl('and');
 
   constructor(
     private route: ActivatedRoute,
@@ -28,40 +29,33 @@ export class SkillListFileterComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    console.log('ngOnInit');
-
     this.route.queryParamMap.subscribe((map) => {
-      // this.tagRule.patchValue(map.get('rule') || 'and', {
-      //   emitEvent: false,
-      // });
+      this.tagRule.patchValue(map.get('rule') || 'and', {
+        emitEvent: false,
+      });
 
-      // const tagFilter = map.get('tagFilter') || '';
-      // this.tagFilter.patchValue(tagFilter, {
-      //   emitEvent: false,
-      // });
-
-      console.log('skill-list-fileter.subscribe');
+      const tagFilter = map.get('tagFilter') || '';
+      this.tagFilter.patchValue(tagFilter, {
+        emitEvent: false,
+      });
 
       const defaultTags = map.get('tags') ? map.get('tags').split(',') : [];
-      this.buildTags('', defaultTags);
-      // console.log('defaultTags:' + defaultTags);
-
-      // this.tags.forEach((tag) => {
-      //   tag.selected = defaultTags.includes(tag.value);
-      // });
+      this.buildTags(tagFilter, defaultTags);
     });
 
-    // this.tagFilter.valueChanges.subscribe((facetQuery) => {
-    //   this.updateParams({
-    //     tagFilter: facetQuery || null,
-    //   });
-    // });
-    // this.tagRule.valueChanges.subscribe((rule) => {
-    //   this.updateParams({
-    //     rule,
-    //   });
-    // });
+    this.tagFilter.valueChanges.subscribe((facetQuery) => {
+      this.updateParams({
+        tagFilter: facetQuery || null,
+      });
+    });
+
+    this.tagRule.valueChanges.subscribe((rule) => {
+      this.updateParams({
+        rule,
+      });
+    });
   }
+
   private updateParams(params: object) {
     this.router.navigate([], {
       queryParamsHandling: 'merge',
@@ -70,16 +64,15 @@ export class SkillListFileterComponent implements OnInit {
   }
 
   private buildTags(facetQuery: string = '', defaultTags?: string[]) {
-    console.log('buildTags' + defaultTags);
-    this.index.searchForFacetValues('skillCategories', '').then((result) => {
-      console.log('before:' + JSON.stringify(this.tags));
-      this.tags = result.facetHits.map((tag) => ({
-        ...tag,
-        selected: defaultTags && defaultTags.includes(tag.value),
-      }));
-      console.log('after:' + JSON.stringify(this.tags));
-    });
-    this.tags[0].value = this.tags[0].value + '_';
+    this.index
+      .searchForFacetValues('skillCategories', facetQuery)
+      .then((result) => {
+        this.tags = result.facetHits.map((tag) => ({
+          ...tag,
+          selected: defaultTags && defaultTags.includes(tag.value),
+        }));
+        console.log('tags:' + JSON.stringify(this.tags));
+      });
   }
 
   updateTags(event: MatSelectionListChange) {

--- a/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
+++ b/src/app/skill-list/skill-list-fileter/skill-list-fileter.component.ts
@@ -3,7 +3,6 @@ import { SkillService } from 'src/app/services/skill.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl } from '@angular/forms';
 import { MatSelectionListChange } from '@angular/material/list';
-import { JsonPipe } from '@angular/common';
 
 @Component({
   selector: 'app-skill-list-fileter',
@@ -21,6 +20,7 @@ export class SkillListFileterComponent implements OnInit {
   }[] = [];
   tagFilter = new FormControl();
   tagRule = new FormControl('and');
+  tagControl = new FormControl();
 
   constructor(
     private route: ActivatedRoute,
@@ -67,11 +67,8 @@ export class SkillListFileterComponent implements OnInit {
     this.index
       .searchForFacetValues('skillCategories', facetQuery)
       .then((result) => {
-        this.tags = result.facetHits.map((tag) => ({
-          ...tag,
-          selected: defaultTags && defaultTags.includes(tag.value),
-        }));
-        console.log('tags:' + JSON.stringify(this.tags));
+        this.tags = result.facetHits;
+        this.tagControl.patchValue(defaultTags, { emitEvent: false });
       });
   }
 

--- a/src/app/skill-list/skill-list.module.ts
+++ b/src/app/skill-list/skill-list.module.ts
@@ -6,14 +6,36 @@ import { SkillListComponent } from './skill-list/skill-list.component';
 import { SkillListCardComponent } from './skill-list-card/skill-list-card.component';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { MatCardModule } from '@angular/material/card';
+import { SkillListFileterComponent } from './skill-list-fileter/skill-list-fileter.component';
+import { MatSelectModule } from '@angular/material/select';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SharedModule } from '../shared/shared.module';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
-  declarations: [SkillListComponent, SkillListCardComponent],
+  declarations: [
+    SkillListComponent,
+    SkillListCardComponent,
+    SkillListFileterComponent,
+  ],
   imports: [
     CommonModule,
     SkillListRoutingModule,
     MatGridListModule,
     MatCardModule,
+    MatSelectModule,
+    MatInputModule,
+    MatListModule,
+    MatFormFieldModule,
+    FormsModule,
+    ReactiveFormsModule,
+    SharedModule,
+    MatIconModule,
+    MatButtonModule,
   ],
 })
 export class SkillListModule {}

--- a/src/app/skill-list/skill-list/skill-list.component.html
+++ b/src/app/skill-list/skill-list/skill-list.component.html
@@ -1,9 +1,19 @@
 <div class="container">
   <div class="content">
     <h1>スキル一覧</h1>
-    <div class="grid">
-      <app-skill-list-card *ngFor="let skill of skills" [skill]="skill">
-      </app-skill-list-card>
+    <div class="content__body">
+      <div class="grid">
+        <app-skill-list-card *ngFor="let skill of skills" [skill]="skill">
+        </app-skill-list-card>
+      </div>
+      <div class="filter">
+        <app-skill-list-fileter></app-skill-list-fileter>
+      </div>
+    </div>
+
+    <div class="content__footer">
+      <app-banner></app-banner>
+      <button mat-button routerLink="./">条件をクリア</button>
     </div>
   </div>
 </div>

--- a/src/app/skill-list/skill-list/skill-list.component.html
+++ b/src/app/skill-list/skill-list/skill-list.component.html
@@ -13,7 +13,6 @@
 
     <div class="content__footer">
       <app-banner></app-banner>
-      <button mat-button routerLink="./">条件をクリア</button>
     </div>
   </div>
 </div>

--- a/src/app/skill-list/skill-list/skill-list.component.scss
+++ b/src/app/skill-list/skill-list/skill-list.component.scss
@@ -1,9 +1,25 @@
 .content {
-  max-width: 1000px;
+  // max-width: 1000px;
+
+  &__body {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  &__footer {
+    border: 1px solid rgba(0, 0, 0, 0.12);
+  }
 }
 
 .grid {
+  width: 100%;
   display: grid;
   gap: 8px;
   grid-template-columns: repeat(auto-fill, 190px);
+}
+
+.filter {
+  width: 300px;
+  // border: 1px solid rgba(0, 0, 0, 0.12);
+  margin-bottom: 24px;
 }

--- a/src/app/skill-list/skill-list/skill-list.component.scss
+++ b/src/app/skill-list/skill-list/skill-list.component.scss
@@ -1,9 +1,8 @@
 .content {
-  // max-width: 1000px;
-
   &__body {
     display: flex;
     justify-content: space-between;
+    margin-bottom: 24px;
   }
 
   &__footer {
@@ -13,13 +12,13 @@
 
 .grid {
   width: 100%;
+  height: 100%;
   display: grid;
   gap: 8px;
   grid-template-columns: repeat(auto-fill, 190px);
+  margin-right: 8px;
 }
 
 .filter {
   width: 300px;
-  // border: 1px solid rgba(0, 0, 0, 0.12);
-  margin-bottom: 24px;
 }

--- a/src/app/skill-list/skill-list/skill-list.component.ts
+++ b/src/app/skill-list/skill-list/skill-list.component.ts
@@ -37,6 +37,8 @@ export class SkillListComponent implements OnInit {
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe((map) => {
+      console.log('skill-list.subscribe');
+
       this.resultList = [];
       // TODO:要実装
       // this.index = this.searchService.index[map.get('sort') || 'popular'];
@@ -45,17 +47,17 @@ export class SkillListComponent implements OnInit {
       //   page: +map.get('page') > 0 ? +map.get('page') - 1 : 0,
       //   hitsPerPage: map.get('perPage') ? +map.get('perPage') : 20,
       // };
-      // this.tagFilter = {
-      //   rule: map.get('rule')?.match(/and|or/) ? map.get('rule') : 'and',
-      //   tags: map.get('tags') ? map.get('tags').split(',') : [],
-      // };
+      this.tagFilter = {
+        rule: map.get('rule')?.match(/and|or/) ? map.get('rule') : 'and',
+        tags: map.get('tags') ? map.get('tags').split(',') : [],
+      };
       this.algoliaSearch();
     });
   }
 
   algoliaSearch() {
     // TODO:要実装
-    // const rule = this.tagFilter.tags.map((tag) => 'categories:' + tag);
+    const rule = this.tagFilter.tags.map((tag) => 'skillCategories:' + tag);
 
     console.log('algoliaSearch');
 
@@ -63,8 +65,8 @@ export class SkillListComponent implements OnInit {
     this.index
       .search<Skill>(this.query, {
         // TODO:要実装
-        //        facetFilters: this.tagFilter.rule === 'and' ? rule : [rule],
-        //        ...this.requestOptions,
+        facetFilters: this.tagFilter.rule === 'and' ? rule : [rule],
+        ...this.requestOptions,
       })
       .then((result) => {
         console.log(result);

--- a/src/app/skill-list/skill-list/skill-list.component.ts
+++ b/src/app/skill-list/skill-list/skill-list.component.ts
@@ -40,9 +40,10 @@ export class SkillListComponent implements OnInit {
       console.log('skill-list.subscribe');
 
       this.resultList = [];
-      // TODO:要実装
+      // TODO:必要があればあとで実装
       // this.index = this.searchService.index[map.get('sort') || 'popular'];
       this.query = map.get('searchQuery') || '';
+      // TODO:必要があればあとで実装
       // this.requestOptions = {
       //   page: +map.get('page') > 0 ? +map.get('page') - 1 : 0,
       //   hitsPerPage: map.get('perPage') ? +map.get('perPage') : 20,
@@ -56,25 +57,20 @@ export class SkillListComponent implements OnInit {
   }
 
   algoliaSearch() {
-    // TODO:要実装
     const rule = this.tagFilter.tags.map((tag) => 'skillCategories:' + tag);
-
-    console.log('algoliaSearch');
 
     this.loading = true;
     this.index
       .search<Skill>(this.query, {
-        // TODO:要実装
         facetFilters: this.tagFilter.rule === 'and' ? rule : [rule],
         ...this.requestOptions,
       })
       .then((result) => {
         console.log(result);
         this.result = result;
-        const items = result.hits as any[]; // TODO: 型対応後調整(https://github.com/algolia/algoliasearch-client-javascript/pull/1086)
+        const items = result.hits as any[];
         this.resultList.push(...items);
         this.loading = false;
-
         this.skills = result.hits as any[];
       });
   }


### PR DESCRIPTION
fix #22 

先ほどはサンプルソースの更新ありがとうございました！
早速、自分のソースにも反映・実装しましたので、レビューをお願いできますでしょうか。

## 概要
スキル一覧にて、スキルカテゴリ(facet)による絞り込みを実装。

## タスク
- [x] Algolia/facetの設定
- [x] 絞り込みエリアのcomponet追加
- [x] queryparamと連動でのフィルタ実装

※補足
基本的には、CAMPサンプルソースの流用です。
page/sortは一旦実装していません。
一通りサービスができたあとで、UI的にあった方が良さそうであれば、実装したいと思います。

## 次のタスク
スクレイピング/Puppeteer設定・連携 #3

※チャート作成・Algolia対応など、まだ未実装の部分ありますが、まずは先に自分のサービス開発に必要な要素を一通りキャッチアップしていきたいと思っています。

## 画面イメージ
### Algolia設定
とりあえず、カテゴリという形になっていますが、あとで以下形式に分割するかも知れません。
（コンテンツが揃ってきたら、どうするか決めたいと思っています）
- カテゴリ→言語・フレームワーク/ライブラリ・インフラ などの大まかな分類分け（単一選択式）
- タグ→そのほかの属性（複数選択式）

![スクリーンショット 2020-06-17 21 35 46](https://user-images.githubusercontent.com/45328438/84901034-de316580-b0e5-11ea-9161-87092841f583.png)

![スクリーンショット 2020-06-17 21 36 27](https://user-images.githubusercontent.com/45328438/84901043-e1c4ec80-b0e5-11ea-8047-95d8c5f1eefd.png)

### Web画面
基本的にはサンプルソースのそのままです。
ただし、UIはまだ仮の感じなので、あとで見直すかもしれません。
（フィルタエリアの位置・開閉式にする等）

![スクリーンショット 2020-06-17 21 33 04](https://user-images.githubusercontent.com/45328438/84901126-fef9bb00-b0e5-11ea-98fe-27904bf82227.png)

![スクリーンショット 2020-06-17 21 32 49](https://user-images.githubusercontent.com/45328438/84901117-fb663400-b0e5-11ea-8984-8e1043c43927.png)

![スクリーンショット 2020-06-17 21 33 48](https://user-images.githubusercontent.com/45328438/84901128-002ae800-b0e6-11ea-9336-c42869188398.png)
