### PR TITLE
スクレイピング/トークン認証・ミニマム実行モード・エラーハンドリング #99

### DIFF
--- a/functions/src/algolia/algolia.client.ts
+++ b/functions/src/algolia/algolia.client.ts
@@ -14,11 +14,11 @@ export class AlgoliaClinent {
     this.index = client.initIndex(indexName);
   }
 
-  deleteIndex(id: string) {
+  deleteObject(id: string) {
     return this.index.deleteObject(id);
   }
 
-  saveIndex(id: string, fsData: any) {
+  saveObject(id: string, fsData: any) {
     const agData = fsData;
     agData.objectID = id;
 

--- a/functions/src/firestore/skill.function.ts
+++ b/functions/src/firestore/skill.function.ts
@@ -7,19 +7,19 @@ export const skillCreate = functions
   .region('asia-northeast1')
   .firestore.document('skills/{id}')
   .onCreate(async (snap, context) => {
-    return algoliaClient.saveIndex(snap.id, snap.data());
+    return algoliaClient.saveObject(snap.id, snap.data());
   });
 
 export const skillUpdate = functions
   .region('asia-northeast1')
   .firestore.document('skills/{id}')
   .onUpdate(async (snap, context) => {
-    return algoliaClient.saveIndex(snap.after.id, snap.after.data());
+    return algoliaClient.saveObject(snap.after.id, snap.after.data());
   });
 
 export const skillDelete = functions
   .region('asia-northeast1')
   .firestore.document('skills/{id}')
   .onDelete(async (snap, context) => {
-    return algoliaClient.deleteIndex(snap.id);
+    return algoliaClient.deleteObject(snap.id);
   });

--- a/functions/src/scraping/scraping.context.ts
+++ b/functions/src/scraping/scraping.context.ts
@@ -7,8 +7,14 @@ export class ScrapingContext {
   private dataHeader: ScrapingDataHeader;
   private dataList: ScrapingData[] = [];
 
-  constructor(scrapingTarget: string) {
+  // 最小実行モード有無.
+  // 通常のスクレイピング処理だと時間がかかってしまうので、少ない件数だけ素早く実行するためのモード
+  // 開発時の検証を効率化するために利用。(本番では利用しない)
+  private minimumMode: boolean;
+
+  constructor(scrapingTarget: string, minimumMode?: number) {
     this.dataHeader = this.createDataHeader(scrapingTarget);
+    this.minimumMode = !!minimumMode;
   }
 
   private createDataHeader(scrapingTarget: string): ScrapingDataHeader {
@@ -43,7 +49,9 @@ export class ScrapingContext {
     return this.dataList;
   }
 
-  // firebase保存先のpath
+  /**
+   * firebase保存先のpath
+   */
   public getCollectionPath(): string {
     return (
       'scraping-data/' +
@@ -53,9 +61,18 @@ export class ScrapingContext {
     );
   }
 
-  // algolia保存先のindex名
-  // (最新データのみ保持するので、dateは不要)
+  /**
+   * algolia保存先のindex名.
+   * 最新データのみ保持するので、dateは不要
+   */
   public getAlgoliaIndexName(): string {
     return 'scraping-data-' + this.dataHeader.scrapingTarget;
+  }
+
+  /**
+   * 最小実行モードか？
+   */
+  public isMinimumMode(): boolean {
+    return this.minimumMode;
   }
 }

--- a/functions/src/scraping/scraping.function.ts
+++ b/functions/src/scraping/scraping.function.ts
@@ -9,16 +9,62 @@ const runtimeOpts: functions.RuntimeOptions = {
   memory: '2GB',
 };
 
-// スクレピング対象が追加された場合、ここに足していく。
+/**
+ * firebase.tokenによる簡易認証.
+ * @param req
+ */
+const httpAuth = function (req: functions.https.Request): boolean {
+  const token = req.query.token;
+  if (!!token && token === functions.config().fb.token) {
+    return true;
+  } else {
+    console.log(
+      'ScrapingFunction.httpAuth.error request:' +
+        JSON.stringify(reqLogInfo(req))
+    );
+    return false;
+  }
+};
+
+/**
+ * ログ出力用のrequest情報を返す.
+ * @param req
+ */
+const reqLogInfo = function (req: functions.https.Request) {
+  return {
+    header: req.headers,
+    query: req.query,
+    body: req.body,
+  };
+};
 
 export const scrapingLevtech = functions
   .region('asia-northeast1')
   .runWith(runtimeOpts)
   .https.onRequest(async (req, res) => {
-    const context = new ScrapingContext('levtech');
-    await new LevtechScraping().exec(context);
-    await new ScrapingFirestore().exec(context);
-    await new ScrapingAlgolia().exec(context); // firestoreで採番されたIDを使うので、firestore保存後に実行
-    // TODO 途中でエラーが発生した場合の挙動(例えば、firestore成功後、algoliaでエラー出たらどうする？)
-    return res.status(200).json(context.getDataHeader());
+    if (!httpAuth(req)) {
+      return res.status(404).send(); // 一般公開用のapiではないので、エラー内容は出さずnot foundで返す
+    }
+
+    try {
+      const context = new ScrapingContext(
+        'levtech',
+        Number(req.query.minimumMode) // オプション増えてきたら、interface化して渡す
+      );
+      await new LevtechScraping().exec(context);
+      await new ScrapingFirestore().exec(context);
+      await new ScrapingAlgolia().exec(context); // firestoreで採番されたIDを使うので、firestore保存後に実行
+      return res
+        .status(200)
+        .json({ status: 'success', result: context.getDataHeader() });
+    } catch (e) {
+      console.log(
+        'scrapingLevtech.error request:' + JSON.stringify(reqLogInfo(req))
+      );
+      console.log('scrapingLevtech.error error:' + JSON.stringify(e));
+      return res.status(500).json({ status: 'error', error: e });
+      // エラー時は、再実行すれば良いので、基本的に復旧処理は不要
+      // (firestore〜algolia間データ不整合が発生する可能性があるが、最新データはalgoliaのみ参照しているので影響なし
+      //  また、再実行で同日付のデータは全削除〜置換されるので、再実行で正常終了すれば、不整合解消される。)
+    }
   });


### PR DESCRIPTION
fix. #99

以下レビューをお願いできますでしょうか。

## 概要
スクレイピング関数(scrapingLevtech)に、トークン認証・ミニマム実行モード・エラーハンドリングを追加。

## タスク
- [x] トークン認証の追加
※前回issueにて追加したfirebase-tokenを利用して、queryParamでtokenを渡して認証するように。
- [x] ミニマム実行モードの追加
※検証作業時に、毎回全件分のスクレイピング処理をしていると時間がかかりfirestoreのアクセス数もかさんでしまうので、最小限(1ページ分)のみで実行できるミニマム実行モードをを追加
- [x] エラーハンドリングの追加
※エラー発生時にはcatchして、エラーログやhttpのレスポンスに適切なエラー情報を出力するように改善
- [x] エラーハンドリング追加に伴い、成功時のレスポンス形式も変更
※処理の成功可否(status)をルート階層に追加(実際の処理結果は、result直下に移動)
- [x] メソッド名リファクタ(AlgoliaClinent.xxxxIndex→xxxxObject)
※実際の動作名とギャップがあったので、修正(保存・削除しているのはindexではなく、index内のobject)

## 動作など
### トークン認証
queryParam[token]にfirebase-tokenを渡して認証。

エラー時は404の空ページを返す。
(一般公開用のapiではないので、エラー内容等はあえて出力しない)
![スクリーンショット 2020-07-13 22 26 27](https://user-images.githubusercontent.com/45328438/87309796-09c63500-c558-11ea-8365-d535907bb24f.png)

ログにはリクエスト内容を出力。
![スクリーンショット 2020-07-13 22 27 01](https://user-images.githubusercontent.com/45328438/87309806-0d59bc00-c558-11ea-980a-816311fa5f54.png)

### ミニマム実行モード&レスポンス形式
queryParam[minimumMode]を渡して実行すると、1ページ分(40件)のみ処理を実行。
(開発時の動作検証を効率的に実施し、firestoreのアクセス量も抑えられる)

また、エラーハンドリングの追加により、成功可否(status:success)を返す。
![スクリーンショット 2020-07-13 22 13 09](https://user-images.githubusercontent.com/45328438/87310452-f23b7c00-c558-11ea-8bae-d093d8c74b0c.png)

### エラーハンドリング
エラー時には、レスポンスで成功可否(status:error)と、エラー内容(error)を返す。
(下記は、algoliaのapikeyに誤りがあった場合の例)
![スクリーンショット 2020-07-13 22 03 02](https://user-images.githubusercontent.com/45328438/87310799-6bd36a00-c559-11ea-9b24-cf02a34a5837.png)

エラーログには、実行時リクエストの内容と、エラー内容を出力。
![スクリーンショット 2020-07-13 22 02 37](https://user-images.githubusercontent.com/45328438/87310825-768dff00-c559-11ea-8d49-a171988944c3.png)
