### PR TITLE
全般/サンプルデータ登録ボタンの削除&rule見直し #102

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -6,7 +6,6 @@ service cloud.firestore {
     match /{document=**} {
       // まずは読込のみ全許可
       allow read: if true;
-      allow write: if true;
     }
   }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -40,7 +40,6 @@
   </mat-autocomplete>
 
   <div class="login">
-    <button mat-button (click)="uploadSampleData()">サンプルデータ更新</button>
     <button mat-button (click)="login()">ログイン</button>
   </div>
 </mat-toolbar>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -57,8 +57,4 @@ export class HeaderComponent implements OnInit {
   navToggle() {
     this.navService.toggle();
   }
-
-  uploadSampleData() {
-    this.skillService.uploadSampleData();
-  }
 }

--- a/src/app/services/skill.service.ts
+++ b/src/app/services/skill.service.ts
@@ -61,80 +61,6 @@ export class SkillService {
     },
   ];
 
-  // 更新用サンプルデータ
-  static SKILLS_FOR_UPLOAD: ReadonlyArray<Skill> = [
-    {
-      skillId: 'angular',
-      skillCaption: 'Angular',
-      skillCategories: ['フレームワーク', 'TypeScript', 'フロントエンド'],
-      price: 500000,
-      vacancy: 100,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-    {
-      skillId: 'vue',
-      skillCaption: 'Vue',
-      skillCategories: ['フレームワーク', 'TypeScript', 'フロントエンド'],
-      price: 400000,
-      vacancy: 80,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-    {
-      skillId: 'react',
-      skillCaption: 'React',
-      skillCategories: ['フレームワーク', 'TypeScript', 'フロントエンド'],
-      price: 300000,
-      vacancy: 60,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-    {
-      skillId: 'java',
-      skillCaption: 'Java',
-      skillCategories: ['言語', 'バックエンド'],
-      price: 380000,
-      vacancy: 180,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-    {
-      skillId: 'rails',
-      skillCaption: 'Ruby on rails',
-      skillCategories: ['フレームワーク', 'Ruby', 'バックエンド'],
-      price: 400000,
-      vacancy: 180,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-    {
-      skillId: 'nodejs',
-      skillCaption: 'Node.js',
-      skillCategories: ['JavaScript'],
-      price: 290000,
-      vacancy: 170,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-    {
-      skillId: 'jquery',
-      skillCaption: 'jQuery',
-      skillCategories: ['JavaScript', 'ライブラリ'],
-      price: 280000,
-      vacancy: 290,
-      aggregatedAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      createdAt: firestore.Timestamp.fromDate(new Date(2020, 5, 1)),
-      updatedAt: firestore.Timestamp.now(),
-    },
-  ];
-
   index = {
     skills: searchClient.initIndex('skills'),
     // ゆくゆくはsort順ごとのindex追加
@@ -156,21 +82,5 @@ export class SkillService {
 
   getTransitionSkills(skillId: string): Skill[] {
     return SkillService.TRANSITION_SKILLS;
-  }
-
-  // 今だけメソッド　テストデータをfirestoreに登録
-  uploadSampleData(): void {
-    console.log('uploadSampleData');
-    SkillService.SKILLS_FOR_UPLOAD.forEach((skill) => {
-      // 更新日
-      (skill.updatedAt = firestore.Timestamp.now()),
-        this.afs
-          .doc('skills/' + skill.skillId)
-          .set(skill)
-          .then(() => {
-            console.log('doc:uploaded' + skill.skillId);
-          });
-    });
-    alert('uploadSampleData.finished!');
   }
 }


### PR DESCRIPTION
fix #102 

## 概要
スクレイピング&集計functionが完成したことによって、今まで仮に作成していたサンプル登録ボタンが不要になったので削除する。
また、firestore更新タイミングも定まったので、ruleを更新。

## タスク
- [x] ヘッダーのサンプル登録ボタンを削除
- [x] 上記に関する各種ソースを削除
- [x] firestore.ruleの修正

## 修正イメージ
### サンプルデータ登録ボタンの削除
ヘッダ右上にあった「サンプルデータ登録」ボタンを削除

・before
![スクリーンショット 2020-07-23 19 52 18](https://user-images.githubusercontent.com/45328438/88358050-73401200-cda8-11ea-85ab-31a1cf6edda9.png)

・after
![スクリーンショット 2020-07-24 12 18 19](https://user-images.githubusercontent.com/45328438/88358200-fc574900-cda8-11ea-933f-844ad1a60e70.png)

### firestore.rule
現状、データ更新はfunctionからしか行われないので、writeの記述を削除
![スクリーンショット 2020-07-24 12 29 06](https://user-images.githubusercontent.com/45328438/88358295-5821d200-cda9-11ea-8ff7-82df8a461745.png)

