### PR TITLE
全般/ngx-pie-chartのマージン調整ディレクティブ #110

### DIFF
--- a/src/app/directives/ngx-pie-chart-zero-margin.directive.spec.ts
+++ b/src/app/directives/ngx-pie-chart-zero-margin.directive.spec.ts
@@ -1,0 +1,9 @@
+import { NgxPieChartZeroMarginDirective } from './ngx-pie-chart-zero-margin.directive';
+import { PieChartComponent } from '@swimlane/ngx-charts';
+
+describe('NgxPieChartZeroMarginDirective', () => {
+  it('should create an instance', () => {
+    const directive = new NgxPieChartZeroMarginDirective(null);
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/ngx-pie-chart-zero-margin.directive.ts
+++ b/src/app/directives/ngx-pie-chart-zero-margin.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, Self } from '@angular/core';
+import { PieChartComponent } from '@swimlane/ngx-charts';
+
+@Directive({
+  selector: '[appNgxPieChartZeroMargin]',
+})
+// ngx-charts-pie-chart専用
+// pie-chartのマージンを削除()
+export class NgxPieChartZeroMarginDirective {
+  constructor(@Self() pieChart: PieChartComponent) {
+    pieChart.margins = [0, 0, 0, 0];
+  }
+}

--- a/src/app/directives/ngx-pie-chart-zero-margin.directive.ts
+++ b/src/app/directives/ngx-pie-chart-zero-margin.directive.ts
@@ -5,9 +5,9 @@ import { PieChartComponent } from '@swimlane/ngx-charts';
   selector: '[appNgxPieChartZeroMargin]',
 })
 // ngx-charts-pie-chart専用
-// pie-chartのマージンを削除()
 export class NgxPieChartZeroMarginDirective {
   constructor(@Self() pieChart: PieChartComponent) {
+    // pie-chartのマージンを削除(デフォルトだと余分な空白が入ってしまう)
     pieChart.margins = [0, 0, 0, 0];
   }
 }

--- a/src/app/shared/breakdown-chart/breakdown-chart.component.html
+++ b/src/app/shared/breakdown-chart/breakdown-chart.component.html
@@ -1,5 +1,6 @@
 <div class="wrapper">
   <ngx-charts-pie-chart
+    appNgxPieChartZeroMargin
     [view]="view"
     [scheme]="colorScheme"
     [results]="chartData"

--- a/src/app/shared/breakdown-chart/breakdown-chart.component.scss
+++ b/src/app/shared/breakdown-chart/breakdown-chart.component.scss
@@ -1,4 +1,3 @@
 ngx-charts-pie-chart {
   display: flex;
-  margin-left: -72px; // ngx-charts側で、多めに余白が付けられるので調整
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -6,6 +6,7 @@ import { SkillsToChartDataGroupPipe } from '../pipes/skills-to-chart-data-group.
 import { TransitionChartComponent } from './transition-chart/transition-chart.component';
 import { NgxChartsModule } from '@swimlane/ngx-charts';
 import { BreakdownChartComponent } from './breakdown-chart/breakdown-chart.component';
+import { NgxPieChartZeroMarginDirective } from '../directives/ngx-pie-chart-zero-margin.directive';
 
 @NgModule({
   declarations: [
@@ -14,6 +15,7 @@ import { BreakdownChartComponent } from './breakdown-chart/breakdown-chart.compo
     SkillsToChartDataGroupPipe,
     TransitionChartComponent,
     BreakdownChartComponent,
+    NgxPieChartZeroMarginDirective,
   ],
   imports: [CommonModule, NgxChartsModule],
   exports: [

--- a/src/app/skill-detail/skill-detail-breakdown/skill-detail-breakdown.component.html
+++ b/src/app/skill-detail/skill-detail-breakdown/skill-detail-breakdown.component.html
@@ -7,7 +7,7 @@
       <app-breakdown-chart
         [chartData]="prefecturesChartData | async"
         [showLegend]="false"
-        [view]="[540, 360]"
+        [view]="[480, 360]"
       ></app-breakdown-chart>
     </div>
   </div>


### PR DESCRIPTION
fix #110 

先ほどMTGにて質問させていただいた件です。
・ngx-chart(pie-chart)の表示位置調整方法について
　https://github.com/camp-team/camp-team/issues/425


ディレクティブ追加にて、無事対応できました！
ありがとうございます！

以下修正内容になりますので、レビューをお願いできますでしょうか？

## 概要
ngx-pie-chartは、表示幅(view)を指定しても余分なマージンが勝手に入ってしまう。

なので、それを解決するための専用ディレクティブを追加

## タスク
- [x] マージン調整ディレクティブの追加(NgxPieChartZeroMarginDirective)
- [x] ディレクティブの呼び出し(breakdown-chart.component.html)
- [x] view調整や、不要になったスタイルの削除

## 修正イメージ
### before
呼び出し元のCSSで、マイナスのmarginをつけて、無理やり左側にずらしていた。
![88470673-491e5980-cf3a-11ea-8725-b16fea631b2e](https://user-images.githubusercontent.com/45328438/88476502-d7630180-cf73-11ea-8651-3e12ddd551cb.png)

### after
ディレクティブにて、pie-chart内部のmarginを削除。
呼び出し元のCSSがなくても、適切に表示されるようになった。
(全体的なUIはまた別途修正予定です。)
![スクリーンショット 2020-07-26 19 08 11](https://user-images.githubusercontent.com/45328438/88476507-dd58e280-cf73-11ea-8edc-f43bdd7e1443.png)