### PR TITLE
スキル比較ページ/ExpressionChangedAfterItHasBeenCheckedErrorの解消 #119

### DIFF
--- a/src/app/skill/skill-pill/skill-pill.component.scss
+++ b/src/app/skill/skill-pill/skill-pill.component.scss
@@ -10,7 +10,8 @@
     border-bottom: 1px solid rgba(0, 0, 0, 0.12); // 縦並びになるので、境界の枠を追加
   }
 }
-ß .skill-pill:hover {
+
+.skill-pill:hover {
   background-color: #fafafa;
   z-index: 0; // 左側のborder(他要素で描画)が表示されるように表示順位下げる
 }

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -1,17 +1,7 @@
-import {
-  Component,
-  OnInit,
-  Input,
-  Output,
-  EventEmitter,
-  ViewChild,
-  ElementRef,
-  HostListener,
-} from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { SkillService } from 'src/app/services/skill.service';
 import { Skill } from 'functions/src/interface/skill';
 import { Observable } from 'rxjs';
-import { getMatIconFailedToSanitizeLiteralError } from '@angular/material/icon';
 
 @Component({
   selector: 'app-skill-pill',
@@ -21,10 +11,9 @@ import { getMatIconFailedToSanitizeLiteralError } from '@angular/material/icon';
 export class SkillPillComponent implements OnInit {
   @Input() skillId: string;
   @Input() skillColor: string;
+  @Input() isLargeFont: boolean;
 
   skill$: Observable<Skill>;
-
-  isLargeFont = false;
 
   @Output() removePill: EventEmitter<string> = new EventEmitter();
   @Output() changePill: EventEmitter<string> = new EventEmitter();

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -5,6 +5,7 @@
         *ngFor="let skill of skills; index as i"
         [skillId]="skill"
         [skillColor]="getSkillColor(i)"
+        [isLargeFont]="isSkillPillLargeFont"
         (removePill)="onRemoveSkillPill($event)"
       >
       </app-skill-pill>

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -1,12 +1,5 @@
-import {
-  Component,
-  OnInit,
-  AfterViewChecked,
-  ViewChildren,
-  QueryList,
-} from '@angular/core';
+import { Component, OnInit, AfterViewChecked } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
-import { SkillPillComponent } from '../skill-pill/skill-pill.component';
 
 @Component({
   selector: 'app-skill',
@@ -15,8 +8,7 @@ import { SkillPillComponent } from '../skill-pill/skill-pill.component';
 })
 export class SkillComponent implements OnInit, AfterViewChecked {
   skills: string[];
-
-  @ViewChildren(SkillPillComponent) pillList: QueryList<SkillPillComponent>;
+  isSkillPillLargeFont: boolean;
 
   // TODO #115にて実装見直し
   // https://github.com/camp-team/skill-board/issues/115
@@ -37,10 +29,11 @@ export class SkillComponent implements OnInit, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
-    // 幅広 かつ 4カラム以下の場合、skill-pill内のfontを大きくする
-    const isSkillPillLargeFont =
-      window.innerWidth >= 960 && this.skills.length <= 4; // TODO 検索欄が追加された場合、lenghtの判定を修正 #117
-    this.pillList.forEach((pill) => (pill.isLargeFont = isSkillPillLargeFont));
+    setTimeout(() => {
+      // 幅広 かつ 4カラム以下の場合、skill-pill内のfontを大きくする
+      this.isSkillPillLargeFont =
+        window.innerWidth >= 960 && this.skills.length <= 4; // TODO 検索欄が追加された場合、lenghtの判定を修正 #117
+    }, 0); // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避)
   }
 
   onRemoveSkillPill(removeSkillId: string) {


### PR DESCRIPTION
fix #119 

以下レビューをお願いできますでしょうか。

## 概要
#113 にて、ウィンドウ幅&子要素数による動的font-size判定を行ったが、操作によっては、ExpressionChangedAfterItHasBeenCheckedErrorが発生してしまうのを修正。

また、それに伴ってリファクタして、ロジックをシンプルに。

## 対象のエラー
描画途中に親componentから以下プロパティを書き換えているため、Angularの変更検知でエラーとなる。

skill-pill.component.html
`  [class.skill-pill-large-font]="isLargeFont"`

![スクリーンショット 2020-08-13 15 45 31](https://user-images.githubusercontent.com/45328438/90102683-14086880-dd7c-11ea-8e11-52e09d4320d1.png)

## タスク
- [x] skill-pill.component.scssの余分な記述を削除
- [x] isSkillPillLargeFontの更新をsetTimeoutによる非同期化
- [x] ロジックリファクタ
※ViewChildrenで子componentを取得して、ts上から直接componentの値を書き換えていたが、子には@input経由で値を渡して親componetでは元の値のみ書き換えるように修正

## 参考
【翻訳】Everything you need to know about the ExpressionChangedAfterItHasBeenCheckedError error
https://qiita.com/tomonari-t/items/3fd6d3c30b6b007b0f14
