### PR TITLE
スキル比較ページ/ヘッダ部/スキルの検索〜追加 #117

### DIFF
--- a/src/app/skill/skill-pill/skill-pill.component.html
+++ b/src/app/skill/skill-pill/skill-pill.component.html
@@ -1,8 +1,4 @@
-<div
-  class="skill-pill"
-  [class.skill-pill-large-font]="isLargeFont"
-  *ngIf="skill$ | async as skill"
->
+<div class="skill-pill" [class.skill-pill-large-font]="isLargeFont">
   <span class="skill-pill-bullet" [ngStyle]="{ color: skillColor }">•</span>
 
   <div class="skill-pill-center">

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -16,7 +16,6 @@ export class SkillPillComponent implements OnInit {
   skill$: Observable<Skill>;
 
   @Output() removePill: EventEmitter<string> = new EventEmitter();
-  @Output() changePill: EventEmitter<string> = new EventEmitter();
 
   constructor(private skillService: SkillService) {}
 
@@ -26,9 +25,5 @@ export class SkillPillComponent implements OnInit {
 
   doRemovePill() {
     this.removePill.emit(this.skillId);
-  }
-
-  doChangePill() {
-    this.changePill.emit(this.skillId);
   }
 }

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -1,17 +1,7 @@
-import {
-  Component,
-  OnInit,
-  Input,
-  Output,
-  EventEmitter,
-  ViewChild,
-  ElementRef,
-  HostListener,
-} from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { SkillService } from 'src/app/services/skill.service';
 import { Skill } from 'functions/src/interface/skill';
 import { Observable } from 'rxjs';
-import { getMatIconFailedToSanitizeLiteralError } from '@angular/material/icon';
 
 @Component({
   selector: 'app-skill-pill',

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { SkillService } from 'src/app/services/skill.service';
 import { Skill } from 'functions/src/interface/skill';
-import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-skill-pill',
@@ -9,21 +8,17 @@ import { Observable } from 'rxjs';
   styleUrls: ['./skill-pill.component.scss'],
 })
 export class SkillPillComponent implements OnInit {
-  @Input() skillId: string;
   @Input() skillColor: string;
   @Input() isLargeFont: boolean;
-
-  skill$: Observable<Skill>;
+  @Input() skill: Skill;
 
   @Output() removePill: EventEmitter<string> = new EventEmitter();
 
   constructor(private skillService: SkillService) {}
 
-  ngOnInit(): void {
-    this.skill$ = this.skillService.getSkill(this.skillId);
-  }
+  ngOnInit(): void {}
 
   doRemovePill() {
-    this.removePill.emit(this.skillId);
+    this.removePill.emit(this.skill.skillId);
   }
 }

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.html
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.html
@@ -1,22 +1,11 @@
 <div class="skill-pill" #skillPill>
-  <!-- <form class="search"> -->
   <input
     class="skill-search"
     [formControl]="searchControl"
     placeholder="スキルを追加"
     [matAutocomplete]="auto"
+    (keydown)="doSearchSkillKeyDown($event)"
   />
-  <!-- type="text" -->
-  <!-- (keydown)="doSearchSkillKeyDown($event)" -->
-
-  <!-- <button
-      (click)="doSubmit(searchControl.value)"
-      class="search__button"
-      mat-icon-button
-    >
-      <mat-icon>search</mat-icon>
-    </button> -->
-  <!-- </form> -->
 
   <mat-autocomplete
     #auto="matAutocomplete"

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.html
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.html
@@ -1,0 +1,38 @@
+<div class="skill-pill" #skillPill>
+  <!-- <form class="search"> -->
+  <input
+    class="skill-search"
+    [formControl]="searchControl"
+    placeholder="スキルを追加"
+    [matAutocomplete]="auto"
+  />
+  <!-- type="text" -->
+  <!-- (keydown)="doSearchSkillKeyDown($event)" -->
+
+  <!-- <button
+      (click)="doSubmit(searchControl.value)"
+      class="search__button"
+      mat-icon-button
+    >
+      <mat-icon>search</mat-icon>
+    </button> -->
+  <!-- </form> -->
+
+  <mat-autocomplete
+    #auto="matAutocomplete"
+    [panelWidth]="autoComplateWidth"
+    (optionSelected)="doSelect($event.option.value)"
+  >
+    <mat-option
+      appSkillAutocomplateOption
+      *ngFor="let option of autoComplateOptions"
+      [value]="option"
+      class="skill-pill-option"
+    >
+      <div class="skill-pill-caption">{{ option.skillCaption }}</div>
+      <div class="skill-pill-caterogy">
+        {{ option.skillCategories.join(', ') }}
+      </div>
+    </mat-option>
+  </mat-autocomplete>
+</div>

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.scss
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.scss
@@ -23,19 +23,18 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  // width: 100%;
+  width: 100%;
   z-index: 1;
 
   border: none;
-  box-shadow: none;
   outline: none;
   background: transparent;
 
-  // border-radius: 2px;
+  top: 50%;
   bottom: 50%;
   margin: auto 0;
   padding: 0 45px 0 24px;
-  top: 50%;
+  box-sizing: border-box;
 }
 
 .skill-pill-option {
@@ -61,12 +60,4 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-// SkillComponent#ngAfterViewChecked経由で、[.skill-pill-large-font]がスイッチされるので、それに応じて文字サイズ切り替え
-.skill-pill-large-font .skill-pill-caption {
-  font-size: 20px;
-}
-.skill-pill-large-font .skill-pill-caterogy {
-  font-size: 15px;
 }

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.scss
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.scss
@@ -1,0 +1,72 @@
+.skill-pill {
+  height: 128px;
+  width: 100%;
+  border-right: 1px solid rgba(0, 0, 0, 0.12);
+  position: relative;
+  z-index: 1;
+
+  @media screen and (max-width: 640px) {
+    height: 72px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.12); // 縦並びになるので、境界の枠を追加
+  }
+}
+
+.skill-pill:hover {
+  background-color: #fafafa;
+  z-index: 0; // 左側のborder(他要素で描画)が表示されるように表示順位下げる
+}
+
+.skill-search {
+  height: 100%;
+  font-size: 20px;
+  line-height: 24px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  // width: 100%;
+  z-index: 1;
+
+  border: none;
+  box-shadow: none;
+  outline: none;
+  background: transparent;
+
+  // border-radius: 2px;
+  bottom: 50%;
+  margin: auto 0;
+  padding: 0 45px 0 24px;
+  top: 50%;
+}
+
+.skill-pill-option {
+  line-height: null; // mat-optionのstyleをクリア
+  height: 64px;
+}
+
+.skill-pill-caption {
+  font-size: 16px;
+  line-height: 24px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.skill-pill-caterogy {
+  font-size: 14px;
+  color: rgba(0, 0, 0, 0.54);
+  height: 18px;
+  line-height: 18px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+// SkillComponent#ngAfterViewChecked経由で、[.skill-pill-large-font]がスイッチされるので、それに応じて文字サイズ切り替え
+.skill-pill-large-font .skill-pill-caption {
+  font-size: 20px;
+}
+.skill-pill-large-font .skill-pill-caterogy {
+  font-size: 15px;
+}

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.spec.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SkillSearchPillComponent } from './skill-search-pill.component';
+
+describe('SkillSearchPillComponent', () => {
+  let component: SkillSearchPillComponent;
+  let fixture: ComponentFixture<SkillSearchPillComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SkillSearchPillComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SkillSearchPillComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.ts
@@ -5,10 +5,12 @@ import {
   ViewChild,
   ElementRef,
   AfterViewChecked,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { SkillService } from 'src/app/services/skill.service';
-import { startWith, debounceTime, tap } from 'rxjs/operators';
+import { startWith, debounceTime } from 'rxjs/operators';
 import { Skill } from 'functions/src/interface/skill';
 
 @Component({
@@ -16,6 +18,7 @@ import { Skill } from 'functions/src/interface/skill';
   templateUrl: './skill-search-pill.component.html',
   styleUrls: ['./skill-search-pill.component.scss'],
 })
+// , AfterViewChecked
 export class SkillSearchPillComponent implements OnInit, AfterViewChecked {
   @Input() isLargeFont: boolean;
 
@@ -25,6 +28,8 @@ export class SkillSearchPillComponent implements OnInit, AfterViewChecked {
   index = this.skillService.index.skills;
 
   @ViewChild('skillPill') elm: ElementRef;
+
+  @Output() addPill: EventEmitter<string> = new EventEmitter();
 
   constructor(private skillService: SkillService) {}
 
@@ -39,10 +44,12 @@ export class SkillSearchPillComponent implements OnInit, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
+    // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避);
     setTimeout(() => {
+      console.log('SkillSearchPillComponent.ngAfterViewChecked');
       // autoComplateのサイズを、pillの要素幅に合わせる
       this.autoComplateWidth = this.elm.nativeElement.clientWidth;
-    }, 0); // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避)
+    }, 0);
   }
 
   doSearchSkillKeyDown(event: KeyboardEvent) {
@@ -54,10 +61,7 @@ export class SkillSearchPillComponent implements OnInit, AfterViewChecked {
   }
 
   doSelect(skill: Skill) {
-    console.log('doSelect:' + JSON.stringify(skill));
-  }
-
-  doSubmit(searchQuery: string) {
-    console.log('doSubmit');
+    console.log('doSelect');
+    this.addPill.emit(skill.skillId);
   }
 }

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.ts
@@ -1,0 +1,63 @@
+import {
+  Component,
+  OnInit,
+  Input,
+  ViewChild,
+  ElementRef,
+  AfterViewChecked,
+} from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { SkillService } from 'src/app/services/skill.service';
+import { startWith, debounceTime, tap } from 'rxjs/operators';
+import { Skill } from 'functions/src/interface/skill';
+
+@Component({
+  selector: 'app-skill-search-pill',
+  templateUrl: './skill-search-pill.component.html',
+  styleUrls: ['./skill-search-pill.component.scss'],
+})
+export class SkillSearchPillComponent implements OnInit, AfterViewChecked {
+  @Input() isLargeFont: boolean;
+
+  searchControl = new FormControl('');
+  autoComplateOptions = [];
+  autoComplateWidth: number;
+  index = this.skillService.index.skills;
+
+  @ViewChild('skillPill') elm: ElementRef;
+
+  constructor(private skillService: SkillService) {}
+
+  ngOnInit(): void {
+    this.searchControl.valueChanges
+      .pipe(startWith(''), debounceTime(500))
+      .subscribe((key) => {
+        this.index.search<Skill[]>(key).then((result) => {
+          this.autoComplateOptions = result.hits.slice(0, 4);
+        });
+      });
+  }
+
+  ngAfterViewChecked(): void {
+    setTimeout(() => {
+      // autoComplateのサイズを、pillの要素幅に合わせる
+      this.autoComplateWidth = this.elm.nativeElement.clientWidth;
+    }, 0); // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避)
+  }
+
+  doSearchSkillKeyDown(event: KeyboardEvent) {
+    console.log('doSearchSkillKeyDown');
+    // input中にenter押下で、1番目の候補を選択したと見なす
+    if (event.key === 'Enter' && this.autoComplateOptions.length > 0) {
+      this.doSelect(this.autoComplateOptions[0]);
+    }
+  }
+
+  doSelect(skill: Skill) {
+    console.log('doSelect:' + JSON.stringify(skill));
+  }
+
+  doSubmit(searchQuery: string) {
+    console.log('doSubmit');
+  }
+}

--- a/src/app/skill/skill.module.ts
+++ b/src/app/skill/skill.module.ts
@@ -3,19 +3,29 @@ import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { SkillRoutingModule } from './skill-routing.module';
 import { SkillComponent } from './skill/skill.component';
 import { SkillPillComponent } from './skill-pill/skill-pill.component';
+import { SkillSearchPillComponent } from './skill-search-pill/skill-search-pill.component';
 
 @NgModule({
-  declarations: [SkillComponent, SkillPillComponent],
+  declarations: [SkillComponent, SkillPillComponent, SkillSearchPillComponent],
   imports: [
     CommonModule,
     SkillRoutingModule,
     MatIconModule,
     MatButtonModule,
     MatCardModule,
+    MatAutocompleteModule,
+    MatInputModule,
+    MatFormFieldModule,
+    FormsModule,
+    ReactiveFormsModule,
   ],
 })
 export class SkillModule {}

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -1,14 +1,16 @@
 <div class="content-header">
   <div class="skill-pills">
     <div class="skill-pills__grid">
-      <app-skill-pill
-        *ngFor="let skill of skills; index as i"
-        [skillId]="skill"
-        [skillColor]="getSkillColor(i)"
-        [isLargeFont]="isSkillPillLargeFont"
-        (removePill)="onRemoveSkillPill($event)"
-      >
-      </app-skill-pill>
+      <ng-container *ngFor="let skillId of skillIds; index as i">
+        <app-skill-pill
+          *ngIf="getSkill(skillId) as skill"
+          [skill]="skill"
+          [skillColor]="getSkillColor(i)"
+          [isLargeFont]="isSkillPillLargeFont"
+          (removePill)="onRemoveSkillPill($event)"
+        >
+        </app-skill-pill>
+      </ng-container>
       <app-skill-search-pill
         *ngIf="isShowSkillPillSearch"
         [isLargeFont]="isSkillPillLargeFont"

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -9,6 +9,9 @@
         (removePill)="onRemoveSkillPill($event)"
       >
       </app-skill-pill>
+      <app-skill-search-pill
+        [isLargeFont]="isSkillPillLargeFont"
+      ></app-skill-search-pill>
     </div>
   </div>
 

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -10,7 +10,9 @@
       >
       </app-skill-pill>
       <app-skill-search-pill
+        *ngIf="isShowSkillPillSearch"
         [isLargeFont]="isSkillPillLargeFont"
+        (addPill)="onSearchSelectSkillPill($event)"
       ></app-skill-search-pill>
     </div>
   </div>

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -1,4 +1,10 @@
-import { Component, OnInit, AfterViewChecked } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  AfterViewChecked,
+  AfterViewInit,
+  OnChanges,
+} from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
 @Component({
@@ -9,6 +15,8 @@ import { Router, ActivatedRoute } from '@angular/router';
 export class SkillComponent implements OnInit, AfterViewChecked {
   skills: string[];
   isSkillPillLargeFont: boolean;
+  isShowSkillPillSearch: boolean;
+  readonly maxSkillPillsLength = 5; // スキル欄の最大数
 
   // TODO #115にて実装見直し
   // https://github.com/camp-team/skill-board/issues/115
@@ -24,16 +32,22 @@ export class SkillComponent implements OnInit, AfterViewChecked {
 
   ngOnInit(): void {
     this.route.queryParamMap.subscribe((map) => {
+      // TODO skillIdの重複対策
       this.skills = map.get('skills')?.split(',');
     });
   }
 
   ngAfterViewChecked(): void {
+    // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避)
     setTimeout(() => {
-      // 幅広 かつ 4カラム以下の場合、skill-pill内のfontを大きくする
+      // 幅広 かつ 4カラム以下(検索欄込み)の場合、skill-pill内のfontを大きくする
       this.isSkillPillLargeFont =
-        window.innerWidth >= 960 && this.skills.length <= 4; // TODO 検索欄が追加された場合、lenghtの判定を修正 #117
-    }, 0); // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避)
+        window.innerWidth >= 960 && this.skills.length < 4;
+
+      // 検索欄はskillが最大件数未満の場合のみ表示
+      this.isShowSkillPillSearch =
+        this.skills.length < this.maxSkillPillsLength;
+    }, 0);
   }
 
   onRemoveSkillPill(removeSkillId: string) {
@@ -42,6 +56,17 @@ export class SkillComponent implements OnInit, AfterViewChecked {
       skills: this.skills
         .filter((skillId) => skillId !== removeSkillId)
         .join(','),
+    });
+  }
+
+  onSearchSelectSkillPill(seletSkillId: string) {
+    console.log('onSearchSelectSkillPill');
+
+    this.skills.push(seletSkillId);
+
+    // TODO skillIdの重複対策
+    this.updateParams({
+      skills: this.skills.join(','),
     });
   }
 

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -10,7 +10,7 @@ import { take } from 'rxjs/operators';
   styleUrls: ['./skill.component.scss'],
 })
 export class SkillComponent implements OnInit {
-  // TODO
+  // TODO #121にて保持方法見直し
   readonly allSkillMap = new Map<string, Skill>(); // <skillId, skill>
   skillIds: string[];
 
@@ -42,11 +42,13 @@ export class SkillComponent implements OnInit {
       .subscribe((skills) => {
         console.log('getSkills.subscribe');
 
+        // TODO #121にて保持方法見直し
         // まずskillデータを全読み込み(数10件程度なので、都度アクセスさせず最初に読み込んでしまう)
         skills.forEach((skill) => this.allSkillMap.set(skill.skillId, skill));
         console.log('this.skillMap:' + JSON.stringify(this.allSkillMap));
 
         this.route.queryParamMap.subscribe((map) => {
+          // TODO #121にて保持方法見直し
           // 重複排除のため、一度setを経由する
           this.skillIds = Array.from(new Set(map.get('skills')?.split(',')));
           this.refleshViewProperties();
@@ -103,7 +105,7 @@ export class SkillComponent implements OnInit {
     return this.skillColorScheme[(index + 5) % 5];
   }
 
-  // TODO #115にて実装見直し
+  // TODO #121にて実装見直し
   getSkill(skillId: string): Skill {
     return this.allSkillMap.get(skillId);
   }

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -1,19 +1,19 @@
-import {
-  Component,
-  OnInit,
-  AfterViewChecked,
-  AfterViewInit,
-  OnChanges,
-} from '@angular/core';
+import { Component, OnInit, HostListener } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
+import { SkillService } from 'src/app/services/skill.service';
+import { Skill } from 'functions/src/interface/skill';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-skill',
   templateUrl: './skill.component.html',
   styleUrls: ['./skill.component.scss'],
 })
-export class SkillComponent implements OnInit, AfterViewChecked {
-  skills: string[];
+export class SkillComponent implements OnInit {
+  // TODO
+  readonly allSkillMap = new Map<string, Skill>(); // <skillId, skill>
+  skillIds: string[];
+
   isSkillPillLargeFont: boolean;
   isShowSkillPillSearch: boolean;
   readonly maxSkillPillsLength = 5; // スキル欄の最大数
@@ -28,45 +28,65 @@ export class SkillComponent implements OnInit, AfterViewChecked {
     '#A228AD',
   ];
 
-  constructor(private route: ActivatedRoute, private router: Router) {}
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private skillService: SkillService
+  ) {}
 
   ngOnInit(): void {
-    this.route.queryParamMap.subscribe((map) => {
-      // TODO skillIdの重複対策
-      this.skills = map.get('skills')?.split(',');
-    });
+    console.log('ngOnInit');
+    this.skillService
+      .getSkills()
+      .pipe(take(1))
+      .subscribe((skills) => {
+        console.log('getSkills.subscribe');
+
+        // まずskillデータを全読み込み(数10件程度なので、都度アクセスさせず最初に読み込んでしまう)
+        skills.forEach((skill) => this.allSkillMap.set(skill.skillId, skill));
+        console.log('this.skillMap:' + JSON.stringify(this.allSkillMap));
+
+        this.route.queryParamMap.subscribe((map) => {
+          // 重複排除のため、一度setを経由する
+          this.skillIds = Array.from(new Set(map.get('skills')?.split(',')));
+          this.refleshViewProperties();
+        });
+      });
   }
 
-  ngAfterViewChecked(): void {
-    // ExpressionChangedAfterItHasBeenCheckedError対策(setTimeoutでプロパティ書き換えを処理を非同期化してエラー回避)
-    setTimeout(() => {
-      // 幅広 かつ 4カラム以下(検索欄込み)の場合、skill-pill内のfontを大きくする
-      this.isSkillPillLargeFont =
-        window.innerWidth >= 960 && this.skills.length < 4;
+  @HostListener('window:resize', ['$event'])
+  doWindowResize(event) {
+    this.refleshViewProperties();
+  }
 
-      // 検索欄はskillが最大件数未満の場合のみ表示
-      this.isShowSkillPillSearch =
-        this.skills.length < this.maxSkillPillsLength;
-    }, 0);
+  refleshViewProperties() {
+    // 幅広 かつ 4カラム以下(検索欄込み)の場合、skill-pill内のfontを大きくする
+    this.isSkillPillLargeFont =
+      window.innerWidth >= 960 && this.skillIds.length < 4;
+
+    // 検索欄はskillが最大件数未満の場合のみ表示
+    this.isShowSkillPillSearch =
+      this.skillIds.length < this.maxSkillPillsLength;
   }
 
   onRemoveSkillPill(removeSkillId: string) {
     // 該当のskillIdをqueryParamから除外
     this.updateParams({
-      skills: this.skills
+      skills: this.skillIds
         .filter((skillId) => skillId !== removeSkillId)
         .join(','),
     });
   }
 
-  onSearchSelectSkillPill(seletSkillId: string) {
-    console.log('onSearchSelectSkillPill');
+  onSearchSelectSkillPill(selectSkillId: string) {
+    if (this.skillIds.includes(selectSkillId)) {
+      return; // 重複時は追加しない
+    }
 
-    this.skills.push(seletSkillId);
+    this.skillIds.push(selectSkillId);
 
-    // TODO skillIdの重複対策
     this.updateParams({
-      skills: this.skills.join(','),
+      skills: this.skillIds.join(','),
     });
   }
 
@@ -81,5 +101,10 @@ export class SkillComponent implements OnInit, AfterViewChecked {
   // https://github.com/camp-team/skill-board/issues/115
   getSkillColor(index: number): string {
     return this.skillColorScheme[(index + 5) % 5];
+  }
+
+  // TODO #115にて実装見直し
+  getSkill(skillId: string): Skill {
+    return this.allSkillMap.get(skillId);
   }
 }


### PR DESCRIPTION
fix #117 

以下レビューをお願いできますでしょうか。

※まだ内部的に残課題ありますが、PR単位が大きくなってきてしまったので、一旦PR発行します。
（残課題は、 #121 にて対応）

## 概要
スキル比較ページに、スキルの検索欄を追加。
検索欄はalgoliaを使用し、オートコンプリートにも対応。

## タスク
- [x] algolia関連のソース移植
※headerのスキル検索のソースを流用
- [x] 検索欄のcomponent作成(skill-search-pill)
- [x] autocomplate内容にカテゴリ情報を表示
- [x] autocomplate選択時にスキル情報(skill-pill)を追加
- [x] ngAfterViewCheckedによるプロパティ更新の廃止
※ngAfterViewCheckedに処理を追加したところ、ngAfterViewCheckedが無限ループになってしまったので、HostListenerなどを活用するように修正
- [x] Skillオブジェクトの取得タイミングを修正
※元々SkillPillComponent内で取得していたが、それだとSkillPillComponent描画前に、SkillSearchPillComponent(検索欄)が先に描画されてしまい違和感があったので、親のSkillComponentで読み込むようにした
- [x] レスポンシブ対応

## 実装内容
検索欄にフォーカスがある場合にオートコンプリートが有効になります。
入力に応じて、オートコンプリートが更新されます。
オートコンプリートは、上位4件まで表示します。
![スクリーンショット 2020-08-15 17 01 02](https://user-images.githubusercontent.com/45328438/90308318-937f6e80-df19-11ea-8466-0850db72dc04.png)
![スクリーンショット 2020-08-15 17 01 08](https://user-images.githubusercontent.com/45328438/90308320-95e1c880-df19-11ea-9a52-522e53a4253c.png)
![スクリーンショット 2020-08-15 17 01 30](https://user-images.githubusercontent.com/45328438/90308338-c32e7680-df19-11ea-8d00-73beb5a690da.png)

オートコンプリートの幅は、検索欄のサイズに対応します。
(ウィンドウサイズ変更時にも連動してサイズ変更されます)
![スクリーンショット 2020-08-15 17 21 38](https://user-images.githubusercontent.com/45328438/90308618-d5111900-df1b-11ea-9d84-b09a1749f222.png)


候補選択 またはEnter押下でスキルが選択されます。
Enter時は1番上の候補が選択されたとみなします。
選択済みのスキルを選択してもスルーされます。

![スクリーンショット 2020-08-15 17 12 17](https://user-images.githubusercontent.com/45328438/90308468-c37b4180-df1a-11ea-8b87-8e4ff6f02265.png)


スキルは最大5種類まで比較可能で、5種追加した場合は、検索欄は表示されません。
×ボタンでスキルを減らした場合、再度検索可能になります。

![スクリーンショット 2020-08-15 17 03 01](https://user-images.githubusercontent.com/45328438/90308399-2e784880-df1a-11ea-89d6-0573abcab829.png)
