### PR TITLE
スキル比較ページ/リファクタ/modelオブジェクトの利用 #121

### DIFF
--- a/src/app/services/skill.service.ts
+++ b/src/app/services/skill.service.ts
@@ -34,6 +34,16 @@ export class SkillService {
     return this.afs.doc<Skill>('skills/' + skillId).valueChanges();
   }
 
+  getAllSkillMap(): Observable<Map<string, Skill>> {
+    return this.getSkills().pipe(
+      map((skills) => {
+        const allSkillMap = new Map<string, Skill>();
+        skills.forEach((skill) => allSkillMap.set(skill.skillId, skill));
+        return allSkillMap;
+      })
+    );
+  }
+
   getTransitionSkills(skillId: string): Observable<Skill[]> {
     // 累積データ(history)から、直近の10件を取得
     // ※firestore取得時は件数制限するために降順にしているが、pipe(map)で昇順に戻す

--- a/src/app/skill/model/skill-data.model.ts
+++ b/src/app/skill/model/skill-data.model.ts
@@ -1,0 +1,5 @@
+import { Skill } from 'functions/src/interface/skill';
+
+export interface SkillDataModel extends Skill {
+  skillColor: string;
+}

--- a/src/app/skill/model/skills-header.model.ts
+++ b/src/app/skill/model/skills-header.model.ts
@@ -1,0 +1,81 @@
+import { Skill } from 'functions/src/interface/skill';
+import { ParamMap } from '@angular/router';
+import { SkillDataModel } from './skill-data.model';
+
+export class SkillsHeaderModel {
+  // 全skillのDB値(数10件程度なので、都度アクセスさせず最初に読み込んでしまう)
+  readonly allSkillMap: Map<string, Skill>; // <skillId, skill>
+
+  // 表示用データ
+  private _skills: SkillDataModel[] = [];
+
+  // チャートなどで利用するスキル識別用の色
+  // スキル固有の色を持っているわけではなく、表示順で割当
+  private readonly skillColorScheme = [
+    '#0096EF',
+    '#FF443E',
+    '#FFCA43',
+    '#2FA04E',
+    '#A228AD',
+  ];
+
+  constructor(allSkillMap: Map<string, Skill>) {
+    this.allSkillMap = allSkillMap;
+  }
+
+  toParam() {
+    return { skills: this._skills.map((d) => d.skillId).join(',') };
+  }
+
+  setParam(paramMap: ParamMap): SkillsHeaderModel {
+    // パラメータ重複を排除するため、Setで取得
+    const skillIdSet = new Set<string>(paramMap.get('skills')?.split(','));
+
+    this._skills.splice(0);
+    for (const skillId of skillIdSet.values()) {
+      this.appendSkill(skillId);
+    }
+    return this;
+  }
+
+  /**
+   * 末尾にスキルを追加.
+   * @return 追加有無(無効なskillIdだった場合、追加されない)
+   */
+  appendSkill(skillId: string): boolean {
+    if (this.allSkillMap.has(skillId)) {
+      const skillData = this.allSkillMap.get(skillId) as SkillDataModel;
+      skillData.skillColor = this.getSkillColor(this._skills.length - 1);
+      this._skills.push(skillData);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * スキルの除去.
+   * @return 除去有無(追加されていないskillIdだった場合、除去されない)
+   */
+  removeSkill(skillId: string): boolean {
+    const beforeLenght = this._skills.length;
+    this._skills = this._skills.filter((s) => s.skillId !== skillId);
+
+    if (beforeLenght > this._skills.length) {
+      this._skills.forEach(
+        (s, index) => (s.skillColor = this.getSkillColor(index))
+      ); // indexがずれるので、colorを更新
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  get skills(): SkillDataModel[] {
+    return this._skills;
+  }
+
+  private getSkillColor(index: number): string {
+    return this.skillColorScheme[index % this.skillColorScheme.length];
+  }
+}

--- a/src/app/skill/model/skills-header.model.ts
+++ b/src/app/skill/model/skills-header.model.ts
@@ -40,10 +40,13 @@ export class SkillsHeaderModel {
 
   /**
    * 末尾にスキルを追加.
-   * @return 追加有無(無効なskillIdだった場合、追加されない)
+   * @return 追加有無(無効なskillIdや、追加済みだった場合、追加されない)
    */
   appendSkill(skillId: string): boolean {
-    if (this.allSkillMap.has(skillId)) {
+    if (
+      this.allSkillMap.has(skillId) &&
+      !this.getSkillIds().includes(skillId)
+    ) {
       const skillData = this.allSkillMap.get(skillId) as SkillDataModel;
       skillData.skillColor = this.getSkillColor(this._skills.length - 1);
       this._skills.push(skillData);
@@ -55,7 +58,7 @@ export class SkillsHeaderModel {
 
   /**
    * スキルの除去.
-   * @return 除去有無(追加されていないskillIdだった場合、除去されない)
+   * @return 除去有無(そもそも追加されていないskillIdだった場合、除去されない)
    */
   removeSkill(skillId: string): boolean {
     const beforeLenght = this._skills.length;
@@ -77,5 +80,9 @@ export class SkillsHeaderModel {
 
   private getSkillColor(index: number): string {
     return this.skillColorScheme[index % this.skillColorScheme.length];
+  }
+
+  private getSkillIds(): string[] {
+    return this._skills.map((s) => s.skillId);
   }
 }

--- a/src/app/skill/skill-pill/skill-pill.component.html
+++ b/src/app/skill/skill-pill/skill-pill.component.html
@@ -1,5 +1,7 @@
 <div class="skill-pill" [class.skill-pill-large-font]="isLargeFont">
-  <span class="skill-pill-bullet" [ngStyle]="{ color: skillColor }">•</span>
+  <span class="skill-pill-bullet" [ngStyle]="{ color: skill.skillColor }"
+    >•</span
+  >
 
   <div class="skill-pill-center">
     <div class="skill-pill-caption">{{ skill.skillCaption }}</div>

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { SkillService } from 'src/app/services/skill.service';
 import { Skill } from 'functions/src/interface/skill';
+import { SkillDataModel } from '../model/skill-data.model';
 
 @Component({
   selector: 'app-skill-pill',
@@ -8,9 +9,8 @@ import { Skill } from 'functions/src/interface/skill';
   styleUrls: ['./skill-pill.component.scss'],
 })
 export class SkillPillComponent implements OnInit {
-  @Input() skillColor: string;
   @Input() isLargeFont: boolean;
-  @Input() skill: Skill;
+  @Input() skill: SkillDataModel;
 
   @Output() removePill: EventEmitter<string> = new EventEmitter();
 

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -1,11 +1,10 @@
 <div class="content-header">
   <div class="skill-pills">
     <div class="skill-pills__grid">
-      <ng-container *ngFor="let skillId of skillIds; index as i">
+      <ng-container *ngFor="let skill of skillHeaderModel.skills">
         <app-skill-pill
-          *ngIf="getSkill(skillId) as skill"
+          *ngIf="skill"
           [skill]="skill"
-          [skillColor]="getSkillColor(i)"
           [isLargeFont]="isSkillPillLargeFont"
           (removePill)="onRemoveSkillPill($event)"
         >

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit, HostListener } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { SkillService } from 'src/app/services/skill.service';
-import { Skill } from 'functions/src/interface/skill';
-import { take, map } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 import { SkillsHeaderModel } from '../model/skills-header.model';
 
 @Component({
@@ -25,11 +24,9 @@ export class SkillComponent implements OnInit {
 
   ngOnInit(): void {
     this.skillService
-      .getSkills()
+      .getAllSkillMap()
       .pipe(take(1))
-      .subscribe((skills) => {
-        const allSkillMap = new Map<string, Skill>();
-        skills.forEach((skill) => allSkillMap.set(skill.skillId, skill));
+      .subscribe((allSkillMap) => {
         this.skillHeaderModel = new SkillsHeaderModel(allSkillMap);
 
         this.route.queryParamMap.subscribe((paramMap) => {

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -2,7 +2,8 @@ import { Component, OnInit, HostListener } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { SkillService } from 'src/app/services/skill.service';
 import { Skill } from 'functions/src/interface/skill';
-import { take } from 'rxjs/operators';
+import { take, map } from 'rxjs/operators';
+import { SkillsHeaderModel } from '../model/skills-header.model';
 
 @Component({
   selector: 'app-skill',
@@ -10,23 +11,11 @@ import { take } from 'rxjs/operators';
   styleUrls: ['./skill.component.scss'],
 })
 export class SkillComponent implements OnInit {
-  // TODO #121にて保持方法見直し
-  readonly allSkillMap = new Map<string, Skill>(); // <skillId, skill>
-  skillIds: string[];
+  skillHeaderModel: SkillsHeaderModel;
 
   isSkillPillLargeFont: boolean;
   isShowSkillPillSearch: boolean;
   readonly maxSkillPillsLength = 5; // スキル欄の最大数
-
-  // TODO #115にて実装見直し
-  // https://github.com/camp-team/skill-board/issues/115
-  private readonly skillColorScheme = [
-    '#0096EF',
-    '#FF443E',
-    '#FFCA43',
-    '#2FA04E',
-    '#A228AD',
-  ];
 
   constructor(
     private route: ActivatedRoute,
@@ -35,22 +24,16 @@ export class SkillComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    console.log('ngOnInit');
     this.skillService
       .getSkills()
       .pipe(take(1))
       .subscribe((skills) => {
-        console.log('getSkills.subscribe');
+        const allSkillMap = new Map<string, Skill>();
+        skills.forEach((skill) => allSkillMap.set(skill.skillId, skill));
+        this.skillHeaderModel = new SkillsHeaderModel(allSkillMap);
 
-        // TODO #121にて保持方法見直し
-        // まずskillデータを全読み込み(数10件程度なので、都度アクセスさせず最初に読み込んでしまう)
-        skills.forEach((skill) => this.allSkillMap.set(skill.skillId, skill));
-        console.log('this.skillMap:' + JSON.stringify(this.allSkillMap));
-
-        this.route.queryParamMap.subscribe((map) => {
-          // TODO #121にて保持方法見直し
-          // 重複排除のため、一度setを経由する
-          this.skillIds = Array.from(new Set(map.get('skills')?.split(',')));
+        this.route.queryParamMap.subscribe((paramMap) => {
+          this.skillHeaderModel.setParam(paramMap);
           this.refleshViewProperties();
         });
       });
@@ -64,32 +47,23 @@ export class SkillComponent implements OnInit {
   refleshViewProperties() {
     // 幅広 かつ 4カラム以下(検索欄込み)の場合、skill-pill内のfontを大きくする
     this.isSkillPillLargeFont =
-      window.innerWidth >= 960 && this.skillIds.length < 4;
+      window.innerWidth >= 960 && this.skillHeaderModel.skills.length < 4;
 
     // 検索欄はskillが最大件数未満の場合のみ表示
     this.isShowSkillPillSearch =
-      this.skillIds.length < this.maxSkillPillsLength;
+      this.skillHeaderModel.skills.length < this.maxSkillPillsLength;
   }
 
-  onRemoveSkillPill(removeSkillId: string) {
-    // 該当のskillIdをqueryParamから除外
-    this.updateParams({
-      skills: this.skillIds
-        .filter((skillId) => skillId !== removeSkillId)
-        .join(','),
-    });
-  }
-
-  onSearchSelectSkillPill(selectSkillId: string) {
-    if (this.skillIds.includes(selectSkillId)) {
-      return; // 重複時は追加しない
+  onRemoveSkillPill(skillId: string) {
+    if (this.skillHeaderModel.removeSkill(skillId)) {
+      this.updateParams(this.skillHeaderModel.toParam()); // 成功時のみパラメータ更新
     }
+  }
 
-    this.skillIds.push(selectSkillId);
-
-    this.updateParams({
-      skills: this.skillIds.join(','),
-    });
+  onSearchSelectSkillPill(skillId: string) {
+    if (this.skillHeaderModel.appendSkill(skillId)) {
+      this.updateParams(this.skillHeaderModel.toParam()); // 成功時のみパラメータ更新
+    }
   }
 
   private updateParams(params: object) {
@@ -97,16 +71,5 @@ export class SkillComponent implements OnInit {
       queryParamsHandling: 'merge',
       queryParams: params,
     });
-  }
-
-  // TODO #115にて実装見直し
-  // https://github.com/camp-team/skill-board/issues/115
-  getSkillColor(index: number): string {
-    return this.skillColorScheme[(index + 5) % 5];
-  }
-
-  // TODO #121にて実装見直し
-  getSkill(skillId: string): Skill {
-    return this.allSkillMap.get(skillId);
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -2,10 +2,7 @@
   "extends": "tslint:recommended",
   "rules": {
     "align": {
-      "options": [
-        "parameters",
-        "statements"
-      ]
+      "options": ["parameters", "statements"]
     },
     "array-type": false,
     "arrow-return-shorthand": true,
@@ -16,34 +13,16 @@
     "component-class-suffix": true,
     "contextual-lifecycle": true,
     "directive-class-suffix": true,
-    "directive-selector": [
-      true,
-      "attribute",
-      "app",
-      "camelCase"
-    ],
-    "component-selector": [
-      true,
-      "element",
-      "app",
-      "kebab-case"
-    ],
+    "directive-selector": [true, "attribute", "app", "camelCase"],
+    "component-selector": [true, "element", "app", "kebab-case"],
     "eofline": true,
-    "import-blacklist": [
-      true,
-      "rxjs/Rx"
-    ],
+    "import-blacklist": [true, "rxjs/Rx"],
     "import-spacing": true,
     "indent": {
-      "options": [
-        "spaces"
-      ]
+      "options": ["spaces"]
     },
     "max-classes-per-file": false,
-    "max-line-length": [
-      true,
-      140
-    ],
+    "max-line-length": [true, 140],
     "member-ordering": [
       true,
       {
@@ -55,35 +34,17 @@
         ]
       }
     ],
-    "no-console": [
-      true,
-      "debug",
-      "info",
-      "time",
-      "timeEnd",
-      "trace"
-    ],
+    "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
     "no-empty": false,
-    "no-inferrable-types": [
-      true,
-      "ignore-params"
-    ],
+    "no-inferrable-types": [true, "ignore-params"],
     "no-non-null-assertion": true,
     "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
     "no-var-requires": false,
-    "object-literal-key-quotes": [
-      true,
-      "as-needed"
-    ],
-    "quotemark": [
-      true,
-      "single"
-    ],
+    "object-literal-key-quotes": [true, "as-needed"],
+    "quotemark": [true, "single"],
     "semicolon": {
-      "options": [
-        "always"
-      ]
+      "options": ["always"]
     },
     "space-before-function-paren": {
       "options": {
@@ -116,7 +77,8 @@
       "options": [
         "ban-keywords",
         "check-format",
-        "allow-pascal-case"
+        "allow-pascal-case",
+        "allow-leading-underscore"
       ]
     },
     "whitespace": {
@@ -142,7 +104,5 @@
     "use-lifecycle-interface": true,
     "use-pipe-transform-interface": true
   },
-  "rulesDirectory": [
-    "codelyzer"
-  ]
+  "rulesDirectory": ["codelyzer"]
 }


### PR DESCRIPTION
fix #121 

以下レビューをお願いできますでしょうか？
※今回はリファクタ&不具合修正のみで、サービスの画面・動作に変更はありません。

## 概要
比較ページに表示するスキル情報を管理するためのmodelオブジェクトを作成し、パラメータ同期・スキル追加&除外などの処理を集約。

これによりcomponentではviewの関わるロジックのみ扱うようにして、ソースの可読性・メンテ性を向上させる。
※今回作成したmodelは、#115 で作成するのチャート用のcomponentでも利用予定。

また、パラメータ〜skill情報の同期ロジックを見直したことによって、以下の問題を解決。
・不正なskillIdがQueryParamに含まれていた場合に空のスキル欄が表示されてしまう
・skillが1個もない状態からスキル追加を行うとパラメータに余分な[,]が付加されてしまう

## タスク
- [x] tslintのルール修正
※変数の先頭にアンダースコアを許可(get&set用)
- [x] modelの作成
- [x] componentから、param関連やスキル追加&除外関連のロジックをmodelに移植
- [x] componentから、allSkillMapの作成ロジックをserviceに移植
- [x] param関連のロジック改善(空白や重複・不正IDの除外)
- [x] 各componentで、modelを利用するように修正