### PR TITLE
スキル比較ページ/検索欄の不具合修正 #126

### DIFF
--- a/src/app/skill/model/skills-header.model.ts
+++ b/src/app/skill/model/skills-header.model.ts
@@ -48,7 +48,7 @@ export class SkillsHeaderModel {
       !this.getSkillIds().includes(skillId)
     ) {
       const skillData = this.allSkillMap.get(skillId) as SkillDataModel;
-      skillData.skillColor = this.getSkillColor(this._skills.length - 1);
+      skillData.skillColor = this.getSkillColor(this._skills.length);
       this._skills.push(skillData);
       return true;
     } else {

--- a/src/app/skill/model/skills-header.model.ts
+++ b/src/app/skill/model/skills-header.model.ts
@@ -7,7 +7,7 @@ export class SkillsHeaderModel {
   readonly allSkillMap: Map<string, Skill>; // <skillId, skill>
 
   // 表示用データ
-  private _skills: SkillDataModel[] = [];
+  private skills: SkillDataModel[] = [];
 
   // チャートなどで利用するスキル識別用の色
   // スキル固有の色を持っているわけではなく、表示順で割当
@@ -24,14 +24,14 @@ export class SkillsHeaderModel {
   }
 
   toParam() {
-    return { skills: this._skills.map((d) => d.skillId).join(',') };
+    return { skills: this.skills.map((d) => d.skillId).join(',') };
   }
 
   setParam(paramMap: ParamMap): SkillsHeaderModel {
     // パラメータ重複を排除するため、Setで取得
     const skillIdSet = new Set<string>(paramMap.get('skills')?.split(','));
 
-    this._skills.splice(0);
+    this.skills.splice(0);
     for (const skillId of skillIdSet.values()) {
       this.appendSkill(skillId);
     }
@@ -48,8 +48,8 @@ export class SkillsHeaderModel {
       !this.getSkillIds().includes(skillId)
     ) {
       const skillData = this.allSkillMap.get(skillId) as SkillDataModel;
-      skillData.skillColor = this.getSkillColor(this._skills.length);
-      this._skills.push(skillData);
+      skillData.skillColor = this.getSkillColor(this.skills.length);
+      this.skills.push(skillData);
       return true;
     } else {
       return false;
@@ -61,11 +61,11 @@ export class SkillsHeaderModel {
    * @return 除去有無(そもそも追加されていないskillIdだった場合、除去されない)
    */
   removeSkill(skillId: string): boolean {
-    const beforeLenght = this._skills.length;
-    this._skills = this._skills.filter((s) => s.skillId !== skillId);
+    const beforeLenght = this.skills.length;
+    this.skills = this.skills.filter((s) => s.skillId !== skillId);
 
-    if (beforeLenght > this._skills.length) {
-      this._skills.forEach(
+    if (beforeLenght > this.skills.length) {
+      this.skills.forEach(
         (s, index) => (s.skillColor = this.getSkillColor(index))
       ); // indexがずれるので、colorを更新
       return true;
@@ -74,8 +74,9 @@ export class SkillsHeaderModel {
     }
   }
 
-  get skills(): SkillDataModel[] {
-    return this._skills;
+  getSkills(): ReadonlyArray<SkillDataModel> {
+    // appendSkill&removeSkill以外からの配列の変更を許容したくないので、ReadonlyArrayで返す
+    return this.skills;
   }
 
   private getSkillColor(index: number): string {
@@ -83,6 +84,6 @@ export class SkillsHeaderModel {
   }
 
   private getSkillIds(): string[] {
-    return this._skills.map((s) => s.skillId);
+    return this.skills.map((s) => s.skillId);
   }
 }

--- a/src/app/skill/skill-pill/skill-pill.component.html
+++ b/src/app/skill/skill-pill/skill-pill.component.html
@@ -13,8 +13,8 @@
   <button
     class="skill-pill-button"
     mat-icon-button
-    aria-label="remove skillPill"
-    (click)="doRemovePill()"
+    aria-label="remove"
+    (click)="onRemoveSkill()"
   >
     <mat-icon>clear</mat-icon>
   </button>

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -12,13 +12,13 @@ export class SkillPillComponent implements OnInit {
   @Input() isLargeFont: boolean;
   @Input() skill: SkillDataModel;
 
-  @Output() removePill: EventEmitter<string> = new EventEmitter();
+  @Output() removeSkill: EventEmitter<string> = new EventEmitter();
 
   constructor(private skillService: SkillService) {}
 
   ngOnInit(): void {}
 
-  doRemovePill() {
-    this.removePill.emit(this.skill.skillId);
+  onRemoveSkill() {
+    this.removeSkill.emit(this.skill.skillId);
   }
 }

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.html
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.html
@@ -1,27 +1,28 @@
-<div class="skill-pill" #skillPill>
-  <input
-    class="skill-search"
-    [formControl]="searchControl"
-    placeholder="スキルを追加"
-    [matAutocomplete]="auto"
-    (keydown)="doSearchSkillKeyDown($event)"
-  />
+<form class="search" (ngSubmit)="doSubmit()">
+  <div class="skill-pill" #skillPill>
+    <input
+      class="skill-search"
+      [formControl]="searchControl"
+      placeholder="スキルを追加"
+      [matAutocomplete]="auto"
+    />
 
-  <mat-autocomplete
-    #auto="matAutocomplete"
-    [panelWidth]="autoComplateWidth"
-    (optionSelected)="doSelect($event.option.value)"
-  >
-    <mat-option
-      appSkillAutocomplateOption
-      *ngFor="let option of autoComplateOptions"
-      [value]="option"
-      class="skill-pill-option"
+    <mat-autocomplete
+      #auto="matAutocomplete"
+      [panelWidth]="autoComplateWidth"
+      (optionSelected)="doSelect($event.option.value)"
     >
-      <div class="skill-pill-caption">{{ option.skillCaption }}</div>
-      <div class="skill-pill-caterogy">
-        {{ option.skillCategories.join(', ') }}
-      </div>
-    </mat-option>
-  </mat-autocomplete>
-</div>
+      <mat-option
+        appSkillAutocomplateOption
+        *ngFor="let option of autoComplateOptions"
+        [value]="option"
+        class="skill-pill-option"
+      >
+        <div class="skill-pill-caption">{{ option.skillCaption }}</div>
+        <div class="skill-pill-caterogy">
+          {{ option.skillCategories.join(', ') }}
+        </div>
+      </mat-option>
+    </mat-autocomplete>
+  </div>
+</form>

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.html
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.html
@@ -1,4 +1,4 @@
-<form class="search" (ngSubmit)="doSubmit()">
+<form class="search" (ngSubmit)="onSubmit()">
   <div class="skill-pill" #skillPill>
     <input
       class="skill-search"
@@ -10,7 +10,7 @@
     <mat-autocomplete
       #auto="matAutocomplete"
       [panelWidth]="autoComplateWidth"
-      (optionSelected)="doSelect($event.option.value)"
+      (optionSelected)="onSelect($event.option.value)"
     >
       <mat-option
         appSkillAutocomplateOption

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.ts
@@ -28,7 +28,7 @@ export class SkillSearchPillComponent implements OnInit {
 
   @ViewChild('skillPill') elm: ElementRef;
 
-  @Output() addPill: EventEmitter<string> = new EventEmitter();
+  @Output() appendSkill: EventEmitter<string> = new EventEmitter();
 
   constructor(private skillService: SkillService) {}
 
@@ -47,21 +47,21 @@ export class SkillSearchPillComponent implements OnInit {
   }
 
   @HostListener('window:resize', ['$event'])
-  doWindowResize(event) {
+  onWindowResize(event) {
     // autoComplateのサイズを、pillの要素幅に合わせる
     this.autoComplateWidth = this.elm.nativeElement.clientWidth;
   }
 
-  doSubmit() {
+  onSubmit() {
     this.index.search<Skill[]>(this.searchControl.value).then((result) => {
       if (result.hits.length > 0) {
-        this.doSelect((result.hits[0] as unknown) as Skill);
+        this.onSelect((result.hits[0] as unknown) as Skill);
       }
     });
   }
 
-  doSelect(skill: Skill) {
-    this.addPill.emit(skill.skillId);
+  onSelect(skill: Skill) {
+    this.appendSkill.emit(skill.skillId);
     this.searchControl.setValue('');
   }
 }

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.ts
@@ -48,16 +48,12 @@ export class SkillSearchPillComponent implements OnInit {
     this.autoComplateWidth = this.elm.nativeElement.clientWidth;
   }
 
-  doSearchSkillKeyDown(event: KeyboardEvent) {
-    // input中にenter押下で、1番目の候補を選択したと見なす
-    // 入力から更新にラグを設けているのでautoComplateOptionsの値は使わず、直接検索実施する。
-    if (event.key === 'Enter') {
-      this.index.search<Skill[]>(this.searchControl.value).then((result) => {
-        if (result.hits.length > 0) {
-          this.doSelect((result.hits[0] as unknown) as Skill);
-        }
-      });
-    }
+  doSubmit() {
+    this.index.search<Skill[]>(this.searchControl.value).then((result) => {
+      if (result.hits.length > 0) {
+        this.doSelect((result.hits[0] as unknown) as Skill);
+      }
+    });
   }
 
   doSelect(skill: Skill) {

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.ts
@@ -36,9 +36,13 @@ export class SkillSearchPillComponent implements OnInit {
     this.searchControl.valueChanges
       .pipe(startWith(''), debounceTime(500))
       .subscribe((key) => {
-        this.index.search<Skill[]>(key).then((result) => {
-          this.autoComplateOptions = result.hits.slice(0, 4);
-        });
+        if (key) {
+          this.index.search<Skill[]>(key).then((result) => {
+            this.autoComplateOptions = result.hits.slice(0, 4);
+          });
+        } else {
+          this.autoComplateOptions = [];
+        }
       });
   }
 

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -7,14 +7,14 @@
             *ngIf="skill"
             [skill]="skill"
             [isLargeFont]="isSkillPillLargeFont"
-            (removePill)="onRemoveSkillPill($event)"
+            (removeSkill)="onRemoveSkill($event)"
           >
           </app-skill-pill>
         </ng-container>
         <app-skill-search-pill
           *ngIf="isShowSkillPillSearch"
           [isLargeFont]="isSkillPillLargeFont"
-          (addPill)="onSearchSelectSkillPill($event)"
+          (appendSkill)="onAppendSkill($event)"
         ></app-skill-search-pill>
       </div>
     </div>

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -1,24 +1,26 @@
-<div class="content-header">
-  <div class="skill-pills">
-    <div class="skill-pills__grid">
-      <ng-container *ngFor="let skill of skillHeaderModel.skills">
-        <app-skill-pill
-          *ngIf="skill"
-          [skill]="skill"
+<ng-container *ngIf="skillHeaderModel">
+  <div class="content-header">
+    <div class="skill-pills">
+      <div class="skill-pills__grid">
+        <ng-container *ngFor="let skill of skillHeaderModel.skills">
+          <app-skill-pill
+            *ngIf="skill"
+            [skill]="skill"
+            [isLargeFont]="isSkillPillLargeFont"
+            (removePill)="onRemoveSkillPill($event)"
+          >
+          </app-skill-pill>
+        </ng-container>
+        <app-skill-search-pill
+          *ngIf="isShowSkillPillSearch"
           [isLargeFont]="isSkillPillLargeFont"
-          (removePill)="onRemoveSkillPill($event)"
-        >
-        </app-skill-pill>
-      </ng-container>
-      <app-skill-search-pill
-        *ngIf="isShowSkillPillSearch"
-        [isLargeFont]="isSkillPillLargeFont"
-        (addPill)="onSearchSelectSkillPill($event)"
-      ></app-skill-search-pill>
+          (addPill)="onSearchSelectSkillPill($event)"
+        ></app-skill-search-pill>
+      </div>
     </div>
+
+    <div class="content-filter"></div>
   </div>
 
-  <div class="content-filter"></div>
-</div>
-
-<div class="content-body"></div>
+  <div class="content-body"></div>
+</ng-container>

--- a/src/app/skill/skill/skill.component.html
+++ b/src/app/skill/skill/skill.component.html
@@ -2,7 +2,7 @@
   <div class="content-header">
     <div class="skill-pills">
       <div class="skill-pills__grid">
-        <ng-container *ngFor="let skill of skillHeaderModel.skills">
+        <ng-container *ngFor="let skill of skillHeaderModel.getSkills()">
           <app-skill-pill
             *ngIf="skill"
             [skill]="skill"

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -44,11 +44,11 @@ export class SkillComponent implements OnInit {
   refleshViewProperties() {
     // 幅広 かつ 4カラム以下(検索欄込み)の場合、skill-pill内のfontを大きくする
     this.isSkillPillLargeFont =
-      window.innerWidth >= 960 && this.skillHeaderModel.skills.length < 4;
+      window.innerWidth >= 960 && this.skillHeaderModel.getSkills().length < 4;
 
     // 検索欄はskillが最大件数未満の場合のみ表示
     this.isShowSkillPillSearch =
-      this.skillHeaderModel.skills.length < this.maxSkillPillsLength;
+      this.skillHeaderModel.getSkills().length < this.maxSkillPillsLength;
   }
 
   onRemoveSkill(skillId: string) {

--- a/src/app/skill/skill/skill.component.ts
+++ b/src/app/skill/skill/skill.component.ts
@@ -51,13 +51,13 @@ export class SkillComponent implements OnInit {
       this.skillHeaderModel.skills.length < this.maxSkillPillsLength;
   }
 
-  onRemoveSkillPill(skillId: string) {
+  onRemoveSkill(skillId: string) {
     if (this.skillHeaderModel.removeSkill(skillId)) {
       this.updateParams(this.skillHeaderModel.toParam()); // 成功時のみパラメータ更新
     }
   }
 
-  onSearchSelectSkillPill(skillId: string) {
+  onAppendSkill(skillId: string) {
     if (this.skillHeaderModel.appendSkill(skillId)) {
       this.updateParams(this.skillHeaderModel.toParam()); // 成功時のみパラメータ更新
     }

--- a/tslint.json
+++ b/tslint.json
@@ -74,12 +74,7 @@
       ]
     },
     "variable-name": {
-      "options": [
-        "ban-keywords",
-        "check-format",
-        "allow-pascal-case",
-        "allow-leading-underscore"
-      ]
+      "options": ["ban-keywords", "check-format", "allow-pascal-case"]
     },
     "whitespace": {
       "options": [


### PR DESCRIPTION
fix #126 

以下レビューをお願いできますでしょうか？

## 概要
前issueでの不具合対応やリファクタ。

※基本的な仕様・動作に変更はありません。

## タスク
- [x] 初期描画時に内部的にエラーが出ているのを修正
(skill.componet.htmlに、ngIfの記述追加)
- [x]  検索欄でkeyPress(enter)で選択処理をしていたのを、formのsubmitで行う様に修正
(enter押下だと、かな変換確定のenterで反応してしまうため)
- [x] 色取得ロジック(skill-header.model.getSkillColor)の呼び出し方を修正
(初期描画時に色がずれる。前回リファクタでのでグレード)
- [x] 未入力時はオートコンプリート候補を出さない様に修正
- [x] フィールド名・メソッド名の統一。
(appendSkill〜onAppendSkillなど)
- [x] SkillsHeaderModelのカプセル化方法修正
(getアクセサ廃止。フィールドprefix削除。readonlyArrayを返す等)
- [x] tslintから、allow-leading-underscoreの排除

## 補足
前回issue時に、アドバイスしていただいたallow-leading-underscoreや、get&setアクセサ関連ですが、現時点では以下の方針でやってみることにしました！
(やってみるうちに方針見直すかもしれませんが。)

- angular推奨に従い、フィールド名等に｢ _ ｣のprefixは使わない。
(前回追加したtslintのallow-leading-underscoreは削除)

- classにて、基本的にメンバーはカプセル化しない。
ロジック上、カプセル化する必要がある場合は、getXxxx()・setXxxx()などのメソッドで対応。

- ただし、Interafaceを実装したclassで、Interafaceで定義されたメンバーの値にて、何らかのロジックを噛ませたい場合にget&setアクセサを利用する。
(例：合計などの計算値や、fullname(苗字+名前)など)