### PR TITLE
angularからfunctionsソースのimportを削除 & GithubActionsのビルド方法修正 #129

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Build
-        run: npm run build --prod
+        run: npm run build
       - name: Archive Production Artifact
         uses: actions/upload-artifact@master
         with:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/src/app/skill/model/skill-data.model.ts
+++ b/src/app/skill/model/skill-data.model.ts
@@ -1,4 +1,4 @@
-import { Skill } from 'functions/src/interface/skill';
+import { Skill } from 'src/app/interfaces/skill';
 
 export interface SkillDataModel extends Skill {
   skillColor: string;

--- a/src/app/skill/model/skills-header.model.ts
+++ b/src/app/skill/model/skills-header.model.ts
@@ -1,6 +1,6 @@
-import { Skill } from 'functions/src/interface/skill';
 import { ParamMap } from '@angular/router';
 import { SkillDataModel } from './skill-data.model';
+import { Skill } from 'src/app/interfaces/skill';
 
 export class SkillsHeaderModel {
   // 全skillのDB値(数10件程度なので、都度アクセスさせず最初に読み込んでしまう)

--- a/src/app/skill/skill-pill/skill-pill.component.ts
+++ b/src/app/skill/skill-pill/skill-pill.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { SkillService } from 'src/app/services/skill.service';
-import { Skill } from 'functions/src/interface/skill';
 import { SkillDataModel } from '../model/skill-data.model';
 
 @Component({

--- a/src/app/skill/skill-search-pill/skill-search-pill.component.ts
+++ b/src/app/skill/skill-search-pill/skill-search-pill.component.ts
@@ -11,7 +11,7 @@ import {
 import { FormControl } from '@angular/forms';
 import { SkillService } from 'src/app/services/skill.service';
 import { startWith, debounceTime } from 'rxjs/operators';
-import { Skill } from 'functions/src/interface/skill';
+import { Skill } from 'src/app/interfaces/skill';
 
 @Component({
   selector: 'app-skill-search-pill',


### PR DESCRIPTION
## 概要
angular側からfunctionsソースをimportしており、ローカル以外では動作しない状態だったのを修正。
（github actionsからのデプロイ時にエラー発生）

また、github actionsのビルドに関する以下の修正を実施
![スクリーンショット 2020-09-12 17 27 43](https://user-images.githubusercontent.com/45328438/92991337-2235da00-f51e-11ea-97fa-66461e5db5e5.png)

## タスク
- [x] Skillインターフェイスのimportを修正「functions/src/interface/skill」→「src/app/interfaces/skill」
- [x] ビルド用ymlの npm run build --prod を npm run build  に変更
- [x] Angularルートのpackage.jsonのビルドコマンドを "build": "ng build --prod

## 補足
上記が原因で、github actionsからのbuildでエラー発生していた。
本修正により、build＆deployが成功する様にする。
![スクリーンショット 2020-09-12 16 23 04](https://user-images.githubusercontent.com/45328438/92991733-d5073780-f520-11ea-896f-213cc14c2ec2.png)