### PR TITLE
GithubActionsエラーの解消（environmentの修正） #132

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,19 @@
 export const environment = {
-  production: true
+  production: true,
+  // 現状は、開発環境と同一。
+  // サービス公開のタイミングで環境作成 #131
+  firebase: {
+    apiKey: 'AIzaSyCYWU4ccRrMwo0pgL-VrisEAFqLPOAdbLk',
+    authDomain: 'skill-board-bbe02.firebaseapp.com',
+    databaseURL: 'https://skill-board-bbe02.firebaseio.com',
+    projectId: 'skill-board-bbe02',
+    storageBucket: 'skill-board-bbe02.appspot.com',
+    messagingSenderId: '323121777520',
+    appId: '1:323121777520:web:4fa8afb8c60d9badef9db5',
+    measurementId: 'G-10ZZH9657X',
+  },
+  algolia: {
+    appId: 'PU529L6FSF',
+    searchKey: '371420ca707829c272e2a7eccd88a85b',
+  },
 };


### PR DESCRIPTION
fix #132 

以下レビューをお願いできますでしょうか。

## 概要
本番用の環境設定(environment.prod.ts)の設定が漏れていて、GithubActionsのデプロイがエラーになっていたのを修正

※現時点では、開発環境と共通。
  サービス公開のタイミングで環境を分ける。→ #131 

## タスク
- [x] environment.prod.tsの修正

## エラー内容
environment.prod.tsの設定が空だったので、algolia&firebaseの設定が取得できずエラーとなっていた。
![スクリーンショット 2020-09-16 20 25 59](https://user-images.githubusercontent.com/45328438/93331223-e4f18500-f85a-11ea-880e-11335eda1fa3.png)
